### PR TITLE
Use a negative length to indicate non-masked baselines

### DIFF
--- a/src/katsdpmodels/rfi_mask.py
+++ b/src/katsdpmodels/rfi_mask.py
@@ -48,9 +48,9 @@ class RFIMask(models.SimpleHDF5Model):
     def max_baseline_length(self, frequency: u.Quantity):
         """Determine maximum baseline length for which data at `frequency` should be masked.
 
-        If the frequency is not masked at all, returns 0.0, and if it is masked
-        at all baseline lengths, returns +inf. One may also supply an array of
-        frequencies and receive an array of responses.
+        If the frequency is not masked at all, returns a negative length, and
+        if it is masked at all baseline lengths, returns +inf. One may also
+        supply an array of frequencies and receive an array of responses.
         """
         raise NotImplementedError()      # pragma: nocover
 
@@ -90,7 +90,7 @@ class RFIMaskRanges(RFIMask):
         b = np.broadcast_to(self.ranges['max_baseline'], in_range.shape, subok=True)
         return np.max(b,
                       axis=-1, where=in_range,
-                      initial=0.0 * self.ranges['max_baseline'].unit)
+                      initial=-1.0 * self.ranges['max_baseline'].unit)
 
     @classmethod
     def from_hdf5(cls: Type[_R], hdf5: h5py.File) -> _R:

--- a/test/test_rfi_mask.py
+++ b/test/test_rfi_mask.py
@@ -61,11 +61,11 @@ def test_is_masked_vector(ranges_model):
 @pytest.mark.parametrize(
     'frequency,result',
     [
-        (90e6 * u.Hz, 0 * u.m),
-        (90 * u.MHz, 0 * u.m),
+        (90e6 * u.Hz, -1 * u.m),
+        (90 * u.MHz, -1 * u.m),
         (110e6 * u.Hz, 1000 * u.m),
         (110 * u.MHz, 1000 * u.m),
-        (300 * u.MHz, 0 * u.m),
+        (300 * u.MHz, -1 * u.m),
         (600 * u.MHz, np.inf * u.m)
     ])
 def test_max_baseline_length_scalar(frequency, result, ranges_model):
@@ -77,15 +77,15 @@ def test_max_baseline_length_vector(ranges_model):
     result = ranges_model.max_baseline_length(frequency)
     np.testing.assert_array_equal(
         result.to_value(u.m),
-        [0, 1000, 0, np.inf, 0]
+        [-1, 1000, -1, np.inf, -1]
     )
 
 
 def test_max_baseline_length_empty(ranges_model):
     ranges_model.ranges.remove_rows(np.s_[:])
-    assert ranges_model.max_baseline_length(1 * u.Hz) == 0 * u.m
+    assert ranges_model.max_baseline_length(1 * u.Hz) == -1 * u.m
     result = ranges_model.max_baseline_length([1, 2] * u.Hz)
-    np.testing.assert_array_equal(result.to_value(u.m), [0.0, 0.0])
+    np.testing.assert_array_equal(result.to_value(u.m), [-1.0, -1.0])
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This avoids any ambiguity about whether autocorrelations are masked.