### PR TITLE
Support writing models to file

### DIFF
--- a/src/katsdpmodels/fetch/__init__.py
+++ b/src/katsdpmodels/fetch/__init__.py
@@ -18,13 +18,13 @@ import contextlib
 import enum
 import hashlib
 import logging
-import io
 import pathlib
 import re
 import urllib.parse
-from typing import List, Dict, Generator, Mapping, MutableMapping, Optional, Type, TypeVar, cast
+from typing import List, Dict, Generator, Mapping, MutableMapping, Optional, Type, TypeVar
 
 from .. import models
+from ..models import _FileLike
 
 
 MAX_ALIASES = 30     #: Maximum number of aliases that will be followed to find a model
@@ -106,7 +106,7 @@ class FileResponse(Response):
     """
 
     def __init__(self, url: str, headers: Mapping[str, str],
-                 file: io.IOBase, content: Optional[bytes] = None) -> None:
+                 file: _FileLike, content: Optional[bytes] = None) -> None:
         super().__init__(url, headers)
         self.file = file
         self.content = content
@@ -200,7 +200,7 @@ class FetcherBase:
                 else:
                     content = None
                 exit_stack.pop_all()
-                response = FileResponse(path.as_uri(), {}, cast(io.IOBase, file), content)
+                response = FileResponse(path.as_uri(), {}, file, content)
         return response
 
     def _get(self, url: str, model_class: Type[_M]) -> Generator[Request, Response, _M]:

--- a/src/katsdpmodels/fetch/aiohttp.py
+++ b/src/katsdpmodels/fetch/aiohttp.py
@@ -18,7 +18,7 @@
 
 import io
 import urllib.parse
-from typing import List, Dict, Generator, Optional, MutableMapping, Type, TypeVar, Any, cast
+from typing import List, Dict, Generator, Optional, MutableMapping, Type, TypeVar, Any
 
 import aiohttp
 
@@ -105,7 +105,7 @@ class Fetcher(fetch.FetcherBase):
                 content = await resp.read()
                 file = io.BytesIO(content)
                 return fetch.FileResponse(
-                    str(resp.url), resp.headers, file=cast(io.IOBase, file), content=content)
+                    str(resp.url), resp.headers, file=file, content=content)
 
     async def _run(self, gen: Generator[fetch.Request, fetch.Response, _T]) -> _T:
         try:

--- a/src/katsdpmodels/fetch/requests.py
+++ b/src/katsdpmodels/fetch/requests.py
@@ -22,7 +22,7 @@ import re
 import logging
 import os
 import urllib.parse
-from typing import List, Generator, Dict, MutableMapping, Optional, Type, TypeVar, Any, cast
+from typing import List, Generator, Dict, MutableMapping, Optional, Type, TypeVar, Any
 
 import requests
 
@@ -212,7 +212,7 @@ class Fetcher(fetch.FetcherBase):
                 content = resp.content
                 file = io.BytesIO(content)
                 return fetch.FileResponse(
-                    resp.url, resp.headers, file=cast(io.IOBase, file), content=content)
+                    resp.url, resp.headers, file=file, content=content)
         else:
             fh = HttpFile(self._session, request.url)
             # TODO: make HttpFile return the full headers

--- a/src/katsdpmodels/models.py
+++ b/src/katsdpmodels/models.py
@@ -21,7 +21,7 @@ from datetime import datetime, timezone
 import io
 import urllib.parse
 import pathlib
-from typing import Mapping, Optional, Any, ClassVar, Type, TypeVar, Union, overload
+from typing import Mapping, BinaryIO, Optional, Any, ClassVar, Type, TypeVar, Union, overload
 from typing_extensions import Literal
 
 import h5py
@@ -34,6 +34,9 @@ _E = TypeVar('_E', bound='ModelError')
 _M = TypeVar('_M', bound='Model')
 _H = TypeVar('_H', bound='SimpleHDF5Model')
 _T = TypeVar('_T')
+# typeshed doesn't correctly indicate that io.BytesIO and typing.BinaryIO
+# inherit from io.IOBase, so we use this type alias for file-like parameters.
+_FileLike = Union[io.IOBase, io.BytesIO, BinaryIO]
 
 
 class ModelError(ValueError):
@@ -118,7 +121,7 @@ class Model(ABC):
 
     @classmethod
     @abstractmethod
-    def from_file(cls: Type[_M], file: io.IOBase, url: str, *,
+    def from_file(cls: Type[_M], file: _FileLike, url: str, *,
                   content_type: Optional[str] = None) -> _M:
         """Load a model from raw data.
 
@@ -131,7 +134,7 @@ class Model(ABC):
         """
 
     @abstractmethod
-    def to_file(self, file: Union[str, pathlib.Path, io.IOBase], *,
+    def to_file(self, file: Union[str, pathlib.Path, _FileLike], *,
                 content_type: Optional[str] = None) -> None:
         """Write a model to file.
 
@@ -179,7 +182,7 @@ class SimpleHDF5Model(Model):
     """
 
     @classmethod
-    def from_file(cls: Type[_H], file: io.IOBase, url: str, *,
+    def from_file(cls: Type[_H], file: _FileLike, url: str, *,
                   content_type: Optional[str] = None) -> _H:
         with file:
             if content_type is not None:
@@ -217,7 +220,7 @@ class SimpleHDF5Model(Model):
                 else:
                     return model
 
-    def to_file(self, file: Union[str, pathlib.Path, io.IOBase], *,
+    def to_file(self, file: Union[str, pathlib.Path, _FileLike], *,
                 content_type: Optional[str] = None) -> None:
         if self.version is None:
             raise ValueError('Version must be set before writing file')

--- a/src/katsdpmodels/rfi_mask.py
+++ b/src/katsdpmodels/rfi_mask.py
@@ -76,10 +76,22 @@ class RFIMask(models.SimpleHDF5Model):
 class RFIMaskRanges(RFIMask):
     model_format: ClassVar[Literal['rfi_format']] = 'rfi_format'
 
-    def __init__(self, ranges: astropy.table.QTable, mask_auto_correlations: bool) -> None:
-        # TODO: validate the columns and units
-        # TODO: document what the requirements are
-        self.ranges = ranges
+    def __init__(self, ranges: astropy.table.Table, mask_auto_correlations: bool) -> None:
+        cols = ('min_frequency', 'max_frequency', 'max_baseline')
+        units = (u.Hz, u.Hz, u.m)
+        self.ranges = astropy.table.QTable(
+            [ranges[col] for col in cols],
+            names=cols,
+            dtype=(np.float64, np.float64, np.float64)
+        )
+        # Canonicalise the units to simplify to_hdf5 (and also remove the
+        # cost of conversions when methods are called with canonical units).
+        for col, unit in zip(cols, units):
+            # Ensure we haven't been given unit-less data, as <<= will inject
+            # the unit (see https://github.com/astropy/astropy/issues/10514).
+            if self.ranges[col].unit is None:
+                raise u.UnitConversionError(f'Column {col} has no units')
+            self.ranges[col] <<= unit
         self._mask_auto_correlations = mask_auto_correlations
 
     @property
@@ -124,10 +136,15 @@ class RFIMaskRanges(RFIMask):
             ('max_baseline', 'f8')
         ])
         data = models.require_columns(data, expected_dtype)
-        ranges = astropy.table.QTable(data[...], copy=False)
-        ranges['min_frequency'] <<= u.Hz
-        ranges['max_frequency'] <<= u.Hz
-        ranges['max_baseline'] <<= u.m
+        ranges = astropy.table.Table(data[...], copy=False)
+        ranges['min_frequency'].unit = u.Hz
+        ranges['max_frequency'].unit = u.Hz
+        ranges['max_baseline'].unit = u.m
         mask_auto_correlations = models.get_hdf5_attr(
             hdf5.attrs, 'mask_auto_correlations', bool, required=True)
         return cls(ranges, mask_auto_correlations)
+
+    def to_hdf5(self, hdf5: h5py.File) -> None:
+        hdf5.attrs['mask_auto_correlations'] = self.mask_auto_correlations
+        # The constructor ensures we're using unscaled units
+        hdf5.create_dataset('ranges', data=self.ranges.as_array(), track_times=False)

--- a/test/test_fetch_aiohttp.py
+++ b/test/test_fetch_aiohttp.py
@@ -109,6 +109,9 @@ async def test_fetch_model_cached_model_type_error(web_server) -> None:
         def from_hdf5(cls, hdf5: h5py.File) -> 'OtherModel':
             return cls()
 
+        def to_hdf5(self, hdf5: h5py.File) -> None:
+            pass
+
     url = web_server('rfi_mask_ranges.h5')
     async with fetch_aiohttp.Fetcher() as fetcher:
         await fetcher.get(url, DummyModel)

--- a/test/test_fetch_requests.py
+++ b/test/test_fetch_requests.py
@@ -254,6 +254,9 @@ def test_fetch_model_cached_model_type_error(web_server) -> None:
         def from_hdf5(cls, hdf5: h5py.File) -> 'OtherModel':
             return cls()
 
+        def to_hdf5(self, hdf5: h5py.File) -> None:
+            pass
+
     url = web_server('rfi_mask_ranges.h5')
     with fetch_requests.Fetcher() as fetcher:
         fetcher.get(url, DummyModel)

--- a/test/test_models.py
+++ b/test/test_models.py
@@ -178,9 +178,9 @@ def test_hdf5_to_file(clear_metadata: bool, dummy_model: DummyModel) -> None:
         dummy_model.target = None
         dummy_model.created = None
     fh = io.BytesIO()
-    dummy_model.to_file(fh, content_type='application/x-hdf5')                # type: ignore
+    dummy_model.to_file(fh, content_type='application/x-hdf5')
     fh.seek(0)
-    new_model = DummyModel.from_file(fh, 'http://test.invalid/dummy.h5',      # type: ignore
+    new_model = DummyModel.from_file(fh, 'http://test.invalid/dummy.h5',
                                      content_type='application/x-hdf5')
     assert_models_equal(dummy_model, new_model)
 
@@ -188,17 +188,17 @@ def test_hdf5_to_file(clear_metadata: bool, dummy_model: DummyModel) -> None:
 def test_hdf5_to_file_no_version(dummy_model: DummyModel) -> None:
     dummy_model.version = None
     with pytest.raises(ValueError):
-        dummy_model.to_file(io.BytesIO(), content_type='application/x-hdf5')  # type: ignore
+        dummy_model.to_file(io.BytesIO(), content_type='application/x-hdf5')
 
 
 def test_hdf5_to_file_no_content_type_or_filename(dummy_model: DummyModel) -> None:
     with pytest.raises(AttributeError):
-        dummy_model.to_file(io.BytesIO())                                     # type: ignore
+        dummy_model.to_file(io.BytesIO())
 
 
 def test_hdf5_to_file_bad_content_type(dummy_model: DummyModel) -> None:
     with pytest.raises(models.FileTypeError, match='Expected application/x-hdf5, not image/png'):
-        dummy_model.to_file(io.BytesIO(), content_type='image/png')           # type: ignore
+        dummy_model.to_file(io.BytesIO(), content_type='image/png')
 
 
 @pytest.mark.parametrize('path_type', [pathlib.Path, str])
@@ -216,6 +216,6 @@ def test_hdf5_to_file_good_extension(path_type: Union[Type[pathlib.Path], Type[s
                                      tmp_path: pathlib.Path) -> None:
     path = path_type(tmp_path / 'test.h5')
     dummy_model.to_file(path)
-    new_model = dummy_model.from_file(open(path, 'rb'), 'test.h5',            # type: ignore
+    new_model = dummy_model.from_file(open(path, 'rb'), 'test.h5',
                                       content_type='application/x-hdf5')
     assert_models_equal(dummy_model, new_model)

--- a/test/test_models.py
+++ b/test/test_models.py
@@ -16,14 +16,32 @@
 
 """Tests for :mod:`katsdpmodels.models`."""
 
+from datetime import datetime, timezone
 import hashlib
-from typing import Dict
+import io
+import pathlib
+from typing import Dict, Type, Union
 
 import numpy as np
 import pytest
 
 from katsdpmodels import models
 from test_utils import DummyModel
+
+
+@pytest.fixture
+def dummy_model() -> DummyModel:
+    ranges = np.array(
+       [(1, 4.5), (2, -5.5)],
+       dtype=[('a', 'i4'), ('b', 'f8')]
+    )
+    model = DummyModel(ranges)
+    model.author = 'Test author'
+    model.comment = 'Test comment'
+    model.target = 'Test target'
+    model.version = 1
+    model.created = datetime(2020, 6, 15, 14, 11, tzinfo=timezone.utc)
+    return model
 
 
 def test_eq_hash() -> None:
@@ -138,3 +156,66 @@ def test_require_columns_extra_column() -> None:
     expected = np.array([10.0, 15.0, 20.0], dtype=dtype2)
     out = models.require_columns(array, dtype2)
     np.testing.assert_equal(out, expected)
+
+
+def assert_models_equal(model1: DummyModel, model2: DummyModel):
+    assert type(model1) == type(model2)
+    assert model1.model_type == model2.model_type
+    assert model1.model_format == model2.model_format
+    assert model1.comment == model2.comment
+    assert model1.author == model2.author
+    assert model1.target == model2.target
+    assert model1.created == model2.created
+    assert model1.version == model2.version
+    np.testing.assert_array_equal(model1.ranges, model2.ranges)
+
+
+@pytest.mark.parametrize('clear_metadata', [False, True])
+def test_hdf5_to_file(clear_metadata: bool, dummy_model: DummyModel) -> None:
+    if clear_metadata:
+        dummy_model.comment = None
+        dummy_model.author = None
+        dummy_model.target = None
+        dummy_model.created = None
+    fh = io.BytesIO()
+    dummy_model.to_file(fh, content_type='application/x-hdf5')                # type: ignore
+    fh.seek(0)
+    new_model = DummyModel.from_file(fh, 'http://test.invalid/dummy.h5',      # type: ignore
+                                     content_type='application/x-hdf5')
+    assert_models_equal(dummy_model, new_model)
+
+
+def test_hdf5_to_file_no_version(dummy_model: DummyModel) -> None:
+    dummy_model.version = None
+    with pytest.raises(ValueError):
+        dummy_model.to_file(io.BytesIO(), content_type='application/x-hdf5')  # type: ignore
+
+
+def test_hdf5_to_file_no_content_type_or_filename(dummy_model: DummyModel) -> None:
+    with pytest.raises(AttributeError):
+        dummy_model.to_file(io.BytesIO())                                     # type: ignore
+
+
+def test_hdf5_to_file_bad_content_type(dummy_model: DummyModel) -> None:
+    with pytest.raises(models.FileTypeError, match='Expected application/x-hdf5, not image/png'):
+        dummy_model.to_file(io.BytesIO(), content_type='image/png')           # type: ignore
+
+
+@pytest.mark.parametrize('path_type', [pathlib.Path, str])
+def test_hdf5_to_file_bad_extension(path_type: Union[Type[pathlib.Path], Type[str]],
+                                    dummy_model: DummyModel,
+                                    tmp_path: pathlib.Path) -> None:
+    with pytest.raises(models.FileTypeError,
+                       match=r'Expected extension of \.h5 or \.hdf5, not \.foo'):
+        dummy_model.to_file(path_type(tmp_path / 'test.foo'))
+
+
+@pytest.mark.parametrize('path_type', [pathlib.Path, str])
+def test_hdf5_to_file_good_extension(path_type: Union[Type[pathlib.Path], Type[str]],
+                                     dummy_model: DummyModel,
+                                     tmp_path: pathlib.Path) -> None:
+    path = path_type(tmp_path / 'test.h5')
+    dummy_model.to_file(path)
+    new_model = dummy_model.from_file(open(path, 'rb'), 'test.h5',            # type: ignore
+                                      content_type='application/x-hdf5')
+    assert_models_equal(dummy_model, new_model)

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -47,6 +47,7 @@ def get_file_url(filename: str) -> str:
 
 class DummyModel(models.SimpleHDF5Model):
     model_type: ClassVar[Literal['rfi_mask']] = 'rfi_mask'
+    model_format: ClassVar[Literal['ranges']] = 'ranges'
 
     def __init__(self, ranges: Any) -> None:
         self.ranges = ranges
@@ -55,6 +56,9 @@ class DummyModel(models.SimpleHDF5Model):
     @classmethod
     def from_hdf5(cls, hdf5: h5py.File) -> 'DummyModel':
         return cls(hdf5['/ranges'][:])
+
+    def to_hdf5(self, hdf5: h5py.File) -> None:
+        hdf5.create_dataset('ranges', data=self.ranges, track_times=False)
 
     def close(self) -> None:
         super().close()


### PR DESCRIPTION
The to_file method can take either a filename or a file-like. There is
currently no support for uploading with HTTP PUT - it's assumed that
will be handled externally.