### PR TITLE
Fetch models from telescope state

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -52,6 +52,7 @@ intersphinx_mapping = {
     'h5py': ('https://docs.h5py.org/en/stable', None),
     'requests': ('https://requests.readthedocs.io/en/master/', None),
     'aiohttp': ('https://docs.aiohttp.org/en/stable', None),
+    'katsdptelstate': ('https://katsdptelstate.readthedocs.io/en/latest', None)
 }
 
 # -- Options for HTML output -------------------------------------------------

--- a/doc/katsdpmodels.rst
+++ b/doc/katsdpmodels.rst
@@ -12,6 +12,14 @@ Subpackages
 Submodules
 ----------
 
+katsdpmodels.band\_mask module
+------------------------------
+
+.. automodule:: katsdpmodels.band_mask
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 katsdpmodels.models module
 --------------------------
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,9 +36,11 @@ where = src
 test =
     pytest
     pytest-asyncio
+    pytest-mock
     responses
     aioresponses
     tornado
+    katsdptelstate[aio]
 
 requests =
     requests

--- a/src/katsdpmodels/fetch/__init__.py
+++ b/src/katsdpmodels/fetch/__init__.py
@@ -21,7 +21,7 @@ import logging
 import pathlib
 import re
 import urllib.parse
-from typing import List, Dict, Generator, Mapping, MutableMapping, Optional, Type, TypeVar
+from typing import List, Dict, Generator, Mapping, MutableMapping, Optional, Type, TypeVar, Generic
 
 from .. import models
 from ..models import _FileLike
@@ -30,6 +30,7 @@ from ..models import _FileLike
 MAX_ALIASES = 30     #: Maximum number of aliases that will be followed to find a model
 _logger = logging.getLogger(__name__)
 _M = TypeVar('_M', bound=models.Model)
+_TS = TypeVar('_TS')
 
 
 class ResponseType(enum.Enum):
@@ -265,7 +266,18 @@ class FetcherBase:
             self._model_cache = {}     # Allow garbage collection of the old cache
 
 
-class TelescopeStateFetcherBase:
+class TelescopeStateRequest(Generic[_TS]):
+    """A request for a key from a telescope state."""
+
+    def __init__(self, telstate: _TS, key: str) -> None:
+        self.telstate = telstate
+        self.key = key
+
+
+_TSGenerator = Generator[TelescopeStateRequest[_TS], object, str]
+
+
+class TelescopeStateFetcherBase(Generic[_TS]):
     """Base class for fetching models from telescope state.
 
     This is a low-level class not intended for direct usage. It handles
@@ -277,18 +289,19 @@ class TelescopeStateFetcherBase:
     This class is *not* thread-safe.
     """
 
-    def __init__(self) -> None:
+    def __init__(self, telstate: _TS) -> None:
+        self.telstate = telstate
         # Cache of sdp_model_base_url
         self._base_url: Optional[str] = None
 
-    def _get_str(self, key: str) -> Generator[str, object, str]:
+    def _get_str(self, telstate: _TS, key: str) -> _TSGenerator:
         """Get a string-valued key from the telescope state.
 
         It yields the key to the caller, which should either respond
         with the value or throw in an exception.
         """
         try:
-            value = yield key
+            value = yield TelescopeStateRequest(telstate, key)
         except Exception as exc:
             raise models.TelescopeStateError(f'could not get {key}: {exc}') from exc
         if not isinstance(value, str):
@@ -297,8 +310,10 @@ class TelescopeStateFetcherBase:
         else:
             return value
 
-    def _get_url(self, key: str) -> Generator[str, object, str]:
+    def _get_url(self, key: str, *, telstate: Optional[_TS] = None) -> _TSGenerator:
         if self._base_url is None:
-            self._base_url = yield from self._get_str('sdp_model_base_url')
-        rel_url = yield from self._get_str(key)
+            self._base_url = yield from self._get_str(self.telstate, 'sdp_model_base_url')
+        if telstate is None:
+            telstate = self.telstate
+        rel_url = yield from self._get_str(telstate, key)
         return urllib.parse.urljoin(self._base_url, rel_url)

--- a/src/katsdpmodels/fetch/__init__.py
+++ b/src/katsdpmodels/fetch/__init__.py
@@ -278,13 +278,15 @@ _TSGenerator = Generator[TelescopeStateRequest[_TS], object, str]
 
 
 class TelescopeStateFetcherBase(Generic[_TS]):
-    """Base class for fetching models from telescope state.
+    """Fetches models that are referenced by telescope state.
 
-    This is a low-level class not intended for direct usage. It handles
-    the mechanics of deciding which telescope state keys are needed and
-    assembling them into an URL. The details of how to get data out of
-    telescope state (either synchronously or asynchronously) and passing
-    that to a model class is left to the subclass.
+    The telescope state must have a ``sdp_model_base_url`` key with a base
+    URL, and a key per model with an URL relative to this one. If it is
+    missing then a :exc:`KeyError` will be raised from :meth:`get`, rather
+    than the constructor.
+
+    If no fetcher is provided, an internal one will be created, and closed
+    when this object is closed.
 
     This class is *not* thread-safe.
     """

--- a/src/katsdpmodels/fetch/aiohttp.py
+++ b/src/katsdpmodels/fetch/aiohttp.py
@@ -180,17 +180,8 @@ async def fetch_model(url: str, model_class: Type[_M], *,
         return await fetcher.get(url, model_class)
 
 
-class TelescopeStateFetcher(fetch.TelescopeStateFetcherBase):
-    """Fetches models that are referenced by telescope state.
-
-    The telescope state must have a ``sdp_model_base_url`` key with a base
-    URL, and a key per model with an URL relative to this one. If it is
-    missing then a :exc:`KeyError` will be raised from :meth:`get`, rather
-    than the constructor.
-
-    If no fetcher is provided, an internal one will be created, and closed
-    when this object is closed.
-    """
+class TelescopeStateFetcher(fetch.TelescopeStateFetcherBase['katsdptelstate.aio.TelescopeState']):
+    __doc__ = fetch.TelescopeStateFetcherBase.__doc__
 
     def __init__(self,
                  telstate: 'katsdptelstate.aio.TelescopeState',

--- a/src/katsdpmodels/fetch/requests.py
+++ b/src/katsdpmodels/fetch/requests.py
@@ -317,16 +317,7 @@ def fetch_model(url: str, model_class: Type[_M], *,
 
 
 class TelescopeStateFetcher(fetch.TelescopeStateFetcherBase['katsdptelstate.TelescopeState']):
-    """Fetches models that are referenced by telescope state.
-
-    The telescope state must have a ``sdp_model_base_url`` key with a base
-    URL, and a key per model with an URL relative to this one. If it is
-    missing then a :exc:`KeyError` will be raised from :meth:`get`, rather
-    than the constructor.
-
-    If no fetcher is provided, an internal one will be created, and closed
-    when this object is closed.
-    """
+    __doc__ = fetch.TelescopeStateFetcherBase.__doc__
 
     def __init__(self,
                  telstate: 'katsdptelstate.TelescopeState',

--- a/src/katsdpmodels/models.py
+++ b/src/katsdpmodels/models.py
@@ -88,6 +88,10 @@ class AbsoluteAliasError(ModelError):
     """An alias retried to redirect to an absolute URL."""
 
 
+class TelescopeStateError(ModelError):
+    """There was a problem retrieving references from telescope state."""
+
+
 class Model(ABC):
     """Base class for models.
 

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -3,13 +3,19 @@ attrs                           # via pytest
 coverage
 importlib-metadata              # via pytest
 more-itertools                  # via pytest
+msgpack                         # via katsdptelstate
+netifaces                       # via katsdptelstate
 packaging                       # via pytest
 pluggy                          # via pytest
 py                              # via pytest
 pytest
 pytest-asyncio==0.12.0
 pytest-cov
+pytest-mock==3.1.1
+redis                           # via katsdptelstate
 responses==0.10.14
 tornado
 wcwidth                         # via pytest
 zipp                            # via importlib-metadata
+
+katsdptelstate @ git+https://github.com/ska-sa/katsdptelstate

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -25,6 +25,7 @@ from typing import Tuple, Callable, Generator
 import pytest
 import aioresponses
 import responses
+import katsdptelstate
 import tornado.httpserver
 import tornado.netutil
 import tornado.web
@@ -115,3 +116,12 @@ def web_server() -> Generator[Callable[[str], str], None, None]:
 
     loop.call_soon_threadsafe(event.set)
     thread.join()
+
+
+@pytest.fixture
+def telstate() -> katsdptelstate.TelescopeState:
+    """Telescope state with some attributes populated."""
+    telstate = katsdptelstate.TelescopeState()
+    telstate['sdp_model_base_url'] = test_utils.BASE_URL
+    telstate['model_key'] = 'rfi_mask_ranges.h5'
+    return telstate

--- a/test/test_fetch_aiohttp.py
+++ b/test/test_fetch_aiohttp.py
@@ -290,7 +290,7 @@ async def test_telescope_state_fetcher_bad_key(telstate, telstate_fetcher) -> No
         await telstate_fetcher.get('bad_key', DummyModel)
 
 
-async def test_telescope_state_connection_error(telstate_fetcher, mocker) -> None:
+async def test_telescope_state_fetcher_connection_error(telstate_fetcher, mocker) -> None:
     mocker.patch('katsdptelstate.aio.TelescopeState.__getitem__',
                  side_effect=katsdptelstate.ConnectionError('test error'))
     with pytest.raises(models.TelescopeStateError, match='test error'):
@@ -299,4 +299,11 @@ async def test_telescope_state_connection_error(telstate_fetcher, mocker) -> Non
 
 async def test_telescope_state_fetcher_good(telstate_fetcher, mock_aioresponses) -> None:
     model = await telstate_fetcher.get('model_key', DummyModel)
+    assert len(model.ranges) == 2
+
+
+async def test_telescope_state_fetcher_override(telstate_fetcher, mock_aioresponses) -> None:
+    telstate2 = katsdptelstate.aio.TelescopeState()
+    await telstate2.set('another_key', 'rfi_mask_ranges.h5')
+    model = await telstate_fetcher.get('another_key', DummyModel, telstate=telstate2)
     assert len(model.ranges) == 2

--- a/test/test_fetch_aiohttp.py
+++ b/test/test_fetch_aiohttp.py
@@ -24,15 +24,18 @@ import h5py
 import pytest
 import aiohttp
 import yarl
+import katsdptelstate.aio.memory
 
 from katsdpmodels import models, fetch
 import katsdpmodels.fetch.aiohttp as fetch_aiohttp
 from test_utils import get_data, get_data_url, get_file_url, DummyModel
 
 
+pytestmark = [pytest.mark.asyncio]
+
+
 @pytest.mark.parametrize('use_file', [True, False])
 @pytest.mark.parametrize('filename', ['rfi_mask_ranges.h5', 'direct.alias', 'indirect.alias'])
-@pytest.mark.asyncio
 async def test_fetch_model_simple(use_file, filename, web_server) -> None:
     url = get_file_url(filename) if use_file else web_server(filename)
     with await fetch_aiohttp.fetch_model(url, DummyModel) as model:
@@ -41,7 +44,6 @@ async def test_fetch_model_simple(use_file, filename, web_server) -> None:
     assert model.is_closed
 
 
-@pytest.mark.asyncio
 async def test_fetch_model_alias_loop(web_server) -> None:
     url = web_server('loop.alias')
     with pytest.raises(models.TooManyAliasesError) as exc_info:
@@ -50,7 +52,6 @@ async def test_fetch_model_alias_loop(web_server) -> None:
     assert exc_info.value.original_url == url
 
 
-@pytest.mark.asyncio
 async def test_fetch_model_too_many_aliases(web_server, monkeypatch) -> None:
     monkeypatch.setattr(fetch, 'MAX_ALIASES', 1)
     with pytest.raises(models.TooManyAliasesError):
@@ -60,7 +61,6 @@ async def test_fetch_model_too_many_aliases(web_server, monkeypatch) -> None:
         pass
 
 
-@pytest.mark.asyncio
 async def test_fetch_model_absolute_alias(web_server) -> None:
     url = web_server('to_file.alias')
     with pytest.raises(models.AbsoluteAliasError) as exc_info:
@@ -70,7 +70,6 @@ async def test_fetch_model_absolute_alias(web_server) -> None:
 
 
 @pytest.mark.parametrize('filename', ['bad_model_type.h5', 'no_model_type.h5'])
-@pytest.mark.asyncio
 async def test_fetch_model_model_type_error(filename, web_server) -> None:
     url = web_server(filename)
     with pytest.raises(models.ModelTypeError) as exc_info:
@@ -80,7 +79,6 @@ async def test_fetch_model_model_type_error(filename, web_server) -> None:
     assert 'rfi_mask' in str(exc_info.value)
 
 
-@pytest.mark.asyncio
 async def test_fetch_model_bad_created(web_server) -> None:
     url = web_server('bad_created.h5')
     with pytest.raises(models.DataError, match='Invalid creation timestamp') as exc_info:
@@ -90,7 +88,6 @@ async def test_fetch_model_bad_created(web_server) -> None:
 
 
 @pytest.mark.parametrize('filename', ['bad_model_version.h5', 'no_model_version.h5'])
-@pytest.mark.asyncio
 async def test_fetch_model_model_version_error(filename, web_server) -> None:
     url = web_server(filename)
     with pytest.raises(models.ModelVersionError) as exc_info:
@@ -100,7 +97,6 @@ async def test_fetch_model_model_version_error(filename, web_server) -> None:
     assert 'model_version' in str(exc_info.value)
 
 
-@pytest.mark.asyncio
 async def test_fetch_model_cached_model_type_error(web_server) -> None:
     class OtherModel(models.SimpleHDF5Model):
         model_type = 'other'
@@ -121,7 +117,6 @@ async def test_fetch_model_cached_model_type_error(web_server) -> None:
         assert exc_info.value.original_url == url
 
 
-@pytest.mark.asyncio
 async def test_fetch_model_bad_content_type(mock_aioresponses) -> None:
     data = get_data('rfi_mask_ranges.h5')
     url = get_data_url('bad_content_type.h5')
@@ -134,7 +129,6 @@ async def test_fetch_model_bad_content_type(mock_aioresponses) -> None:
     assert exc_info.value.original_url == url
 
 
-@pytest.mark.asyncio
 async def test_fetch_model_bad_extension(web_server) -> None:
     url = web_server('wrong_extension.blah')
     with pytest.raises(models.FileTypeError) as exc_info:
@@ -144,7 +138,6 @@ async def test_fetch_model_bad_extension(web_server) -> None:
     assert exc_info.value.original_url == url
 
 
-@pytest.mark.asyncio
 async def test_fetch_model_not_hdf5(web_server) -> None:
     url = web_server('not_hdf5.h5')
     with pytest.raises(models.DataError) as exc_info:
@@ -153,7 +146,6 @@ async def test_fetch_model_not_hdf5(web_server) -> None:
     assert exc_info.value.original_url == url
 
 
-@pytest.mark.asyncio
 async def test_fetch_model_checksum_ok(mock_aioresponses) -> None:
     data = get_data('rfi_mask_ranges.h5')
     digest = hashlib.sha256(data).hexdigest()
@@ -163,7 +155,6 @@ async def test_fetch_model_checksum_ok(mock_aioresponses) -> None:
         assert model.checksum == digest
 
 
-@pytest.mark.asyncio
 async def test_fetch_model_checksum_bad(mock_aioresponses) -> None:
     data = get_data('rfi_mask_ranges.h5')
     digest = hashlib.sha256(data).hexdigest()
@@ -177,7 +168,6 @@ async def test_fetch_model_checksum_bad(mock_aioresponses) -> None:
 
 
 @pytest.mark.parametrize('filename', ['does_not_exist.h5', 'does_not_exist.alias'])
-@pytest.mark.asyncio
 async def test_fetch_model_bad_http_status(filename, web_server) -> None:
     url = web_server(filename)
     with pytest.raises(aiohttp.ClientError) as exc_info:
@@ -185,7 +175,6 @@ async def test_fetch_model_bad_http_status(filename, web_server) -> None:
     assert exc_info.value.status == 404
 
 
-@pytest.mark.asyncio
 async def test_fetch_model_http_redirect(mock_aioresponses) -> None:
     url = get_data_url('subdir/redirect.alias')
     # aioresponses doesn't properly handle relative URLs in redirects, so we
@@ -198,14 +187,12 @@ async def test_fetch_model_http_redirect(mock_aioresponses) -> None:
         assert len(model.ranges) == 2
 
 
-@pytest.mark.asyncio
 async def test_fetch_model_connection_error(mock_aioresponses) -> None:
     # aioresponses raises ConnectionError for any unregistered URL
     with pytest.raises(aiohttp.ClientConnectionError):
         await fetch_aiohttp.fetch_model(get_data_url('does_not_exist.h5'), DummyModel)
 
 
-@pytest.mark.asyncio
 async def test_fetcher_caching(mock_aioresponses) -> None:
     async with fetch_aiohttp.Fetcher() as fetcher:
         model1 = await fetcher.get(get_data_url('rfi_mask_ranges.h5'), DummyModel)
@@ -230,7 +217,6 @@ def _tracing_session(urls: List[yarl.URL]) -> aiohttp.ClientSession:
     return aiohttp.ClientSession(trace_configs=[trace_config])
 
 
-@pytest.mark.asyncio
 async def test_fetcher_custom_session(web_server) -> None:
     urls: List[yarl.URL] = []
     async with _tracing_session(urls) as session:
@@ -242,7 +228,6 @@ async def test_fetcher_custom_session(web_server) -> None:
     assert session.closed
 
 
-@pytest.mark.asyncio
 async def test_custom_session(web_server) -> None:
     urls: List[yarl.URL] = []
     async with _tracing_session(urls) as session:
@@ -252,7 +237,6 @@ async def test_custom_session(web_server) -> None:
     assert session.closed
 
 
-@pytest.mark.asyncio
 async def test_fetcher_resolve(web_server) -> None:
     url = web_server('indirect.alias')
     async with fetch_aiohttp.Fetcher() as fetcher:
@@ -262,3 +246,57 @@ async def test_fetcher_resolve(web_server) -> None:
         web_server('direct.alias'),
         web_server('rfi_mask_ranges.h5')
     ]
+
+
+@pytest.fixture
+async def telstate(telstate):
+    # Extract the memory store from the sync telstate, wrap into an async telstate
+    backend = katsdptelstate.aio.memory.MemoryBackend.from_sync(telstate.backend)
+    yield katsdptelstate.aio.TelescopeState(backend)
+    backend.close()
+    await backend.wait_closed()
+
+
+@pytest.fixture
+async def telstate_fetcher(telstate):
+    fetcher = fetch_aiohttp.TelescopeStateFetcher(telstate)
+    async with fetcher:
+        yield fetcher
+
+
+async def test_telescope_state_fetcher_missing_base_url(telstate) -> None:
+    await telstate.delete('sdp_model_base_url')
+    async with fetch_aiohttp.TelescopeStateFetcher(telstate) as fetcher:
+        with pytest.raises(models.TelescopeStateError, match='not found'):
+            await fetcher.get('model_key', DummyModel)
+
+
+async def test_telescope_state_fetcher_bad_base_url(telstate) -> None:
+    await telstate.delete('sdp_model_base_url')
+    await telstate.set('sdp_model_base_url', b'Not a string')
+    async with fetch_aiohttp.TelescopeStateFetcher(telstate) as fetcher:
+        with pytest.raises(models.TelescopeStateError, match='should be a str'):
+            await fetcher.get('model_key', DummyModel)
+
+
+async def test_telescope_state_fetcher_missing_key(telstate_fetcher) -> None:
+    with pytest.raises(models.TelescopeStateError, match='not found'):
+        await telstate_fetcher.get('missing_key', DummyModel)
+
+
+async def test_telescope_state_fetcher_bad_key(telstate, telstate_fetcher) -> None:
+    await telstate.set('bad_key', 123)
+    with pytest.raises(models.TelescopeStateError, match='should be a str'):
+        await telstate_fetcher.get('bad_key', DummyModel)
+
+
+async def test_telescope_state_connection_error(telstate_fetcher, mocker) -> None:
+    mocker.patch('katsdptelstate.aio.TelescopeState.__getitem__',
+                 side_effect=katsdptelstate.ConnectionError('test error'))
+    with pytest.raises(models.TelescopeStateError, match='test error'):
+        await telstate_fetcher.get('model_key', DummyModel)
+
+
+async def test_telescope_state_fetcher_good(telstate_fetcher, mock_aioresponses) -> None:
+    model = await telstate_fetcher.get('model_key', DummyModel)
+    assert len(model.ranges) == 2

--- a/test/test_fetch_requests.py
+++ b/test/test_fetch_requests.py
@@ -23,6 +23,7 @@ import h5py
 import pytest
 import requests
 import responses
+import katsdptelstate
 
 from katsdpmodels import models, fetch
 import katsdpmodels.fetch.requests as fetch_requests
@@ -417,3 +418,48 @@ def test_lazy_local() -> None:
     with fetch_requests.Fetcher() as fetcher:
         model = fetcher.get(get_file_url('rfi_mask_ranges.h5'), DummyModel, lazy=True)
         assert len(model.ranges) == 2
+
+
+@pytest.fixture
+def telstate_fetcher(telstate):
+    fetcher = fetch_requests.TelescopeStateFetcher(telstate)
+    with fetcher:
+        yield fetcher
+
+
+def test_telescope_state_fetcher_missing_base_url(telstate) -> None:
+    telstate.delete('sdp_model_base_url')
+    with fetch_requests.TelescopeStateFetcher(telstate) as fetcher:
+        with pytest.raises(models.TelescopeStateError, match='not found'):
+            fetcher.get('model_key', DummyModel)
+
+
+def test_telescope_state_fetcher_bad_base_url(telstate) -> None:
+    telstate.delete('sdp_model_base_url')
+    telstate['sdp_model_base_url'] = b'Not a string'
+    with fetch_requests.TelescopeStateFetcher(telstate) as fetcher:
+        with pytest.raises(models.TelescopeStateError, match='should be a str'):
+            fetcher.get('model_key', DummyModel)
+
+
+def test_telescope_state_fetcher_missing_key(telstate_fetcher) -> None:
+    with pytest.raises(models.TelescopeStateError, match='not found'):
+        telstate_fetcher.get('missing_key', DummyModel)
+
+
+def test_telescope_state_fetcher_bad_key(telstate, telstate_fetcher) -> None:
+    telstate['bad_key'] = 123
+    with pytest.raises(models.TelescopeStateError, match='should be a str'):
+        telstate_fetcher.get('bad_key', DummyModel)
+
+
+def test_telescope_state_connection_error(telstate_fetcher, mocker) -> None:
+    mocker.patch('katsdptelstate.TelescopeState.__getitem__',
+                 side_effect=katsdptelstate.ConnectionError('test error'))
+    with pytest.raises(models.TelescopeStateError, match='test error'):
+        telstate_fetcher.get('model_key', DummyModel)
+
+
+def test_telescope_state_fetcher_good(telstate_fetcher, mock_responses) -> None:
+    model = telstate_fetcher.get('model_key', DummyModel)
+    assert len(model.ranges) == 2

--- a/test/test_fetch_requests.py
+++ b/test/test_fetch_requests.py
@@ -453,7 +453,7 @@ def test_telescope_state_fetcher_bad_key(telstate, telstate_fetcher) -> None:
         telstate_fetcher.get('bad_key', DummyModel)
 
 
-def test_telescope_state_connection_error(telstate_fetcher, mocker) -> None:
+def test_telescope_state_fetcher_connection_error(telstate_fetcher, mocker) -> None:
     mocker.patch('katsdptelstate.TelescopeState.__getitem__',
                  side_effect=katsdptelstate.ConnectionError('test error'))
     with pytest.raises(models.TelescopeStateError, match='test error'):
@@ -462,4 +462,11 @@ def test_telescope_state_connection_error(telstate_fetcher, mocker) -> None:
 
 def test_telescope_state_fetcher_good(telstate_fetcher, mock_responses) -> None:
     model = telstate_fetcher.get('model_key', DummyModel)
+    assert len(model.ranges) == 2
+
+
+def test_telescope_state_fetcher_override(telstate_fetcher, mock_responses) -> None:
+    telstate2 = katsdptelstate.TelescopeState()
+    telstate2['another_key'] = 'rfi_mask_ranges.h5'
+    model = telstate_fetcher.get('another_key', DummyModel, telstate=telstate2)
     assert len(model.ranges) == 2


### PR DESCRIPTION
Add a TelescopeStateFetcher class that combines a TelescopeState and a Fetcher and allows models to be fetched by telescope state key instead of by URL. There are actually two variances, a synchronous one and an asynchronous one. As with Fetcher, the business logic is all put into a generator function in the base class, which the derived class interacts with either synchronously or asynchronously.