### PR TITLE
Do automatic HTTP retries

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 aiohttp
+aiohttp-retry
 astropy
 async-timeout                 # via aiohttp
 attrs                         # via aiohttp

--- a/setup.cfg
+++ b/setup.cfg
@@ -47,3 +47,4 @@ requests =
 
 aiohttp =
     aiohttp
+    aiohttp-retry

--- a/test/test_fetch_requests.py
+++ b/test/test_fetch_requests.py
@@ -195,6 +195,15 @@ def test_fetch_model_simple(use_file, filename, web_server) -> None:
     assert model.is_closed
 
 
+def test_fetch_model_retry(web_server) -> None:
+    """Test that retry happens on a 5xx server error."""
+    url = web_server('rfi_mask_ranges.h5').replace('/static/', '/failonce/')
+    with fetch_requests.fetch_model(url, DummyModel) as model:
+        assert len(model.ranges) == 2
+        assert not model.is_closed
+    assert model.is_closed
+
+
 def test_fetch_model_alias_loop(web_server) -> None:
     url = web_server('loop.alias')
     with pytest.raises(models.TooManyAliasesError) as exc_info:


### PR DESCRIPTION
This is done when the session is created by default. Retries are tried
up to 5 total attempts (including the initial one) on connection errors
and HTTP status 5xx. Unfortunately the logic is slightly different
between the requests and aiohttp backends because aiohttp doesn't have
native retry support and hence it is provided by aiohttp-retry, which
requires the retry options to be passed to each request rather than
stored in the class.