### PR TITLE
Update to aiohttp-retry 2.0

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -47,4 +47,4 @@ requests =
 
 aiohttp =
     aiohttp
-    aiohttp-retry
+    aiohttp-retry>=2.0


### PR DESCRIPTION
It adds the ability to set the retry options when the RetryClient is
constructed, which removes the need to inject retry options when using
it. That also means users can specify their own retry policies.

This will require a matching change in katsdpdockerbase to set the
default version to 2.0.