### PR TITLE
Add channel_bandwidth parameters to RFIMask

### DIFF
--- a/doc/user/formats.rst
+++ b/doc/user/formats.rst
@@ -93,8 +93,7 @@ ranges
 
     min_frequency, max_frequency (float)
         Frequencies of an RFI-affected region of the spectrum. Channels are
-        masked if the channel centre frequency falls into any of the ranges
-        (which include their endpoints).
+        masked if any part of the channel lies inside any of the ranges.
 
     max_baseline (float)
         Maximum (inclusive) baseline length for which these frequencies should

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,4 +1,4 @@
-aioresponses==0.6.4
+aioresponses==0.7.1
 attrs                           # via pytest
 coverage
 importlib-metadata              # via pytest

--- a/test/test_fetch_aiohttp.py
+++ b/test/test_fetch_aiohttp.py
@@ -190,8 +190,6 @@ async def test_fetch_model_http_redirect(mock_aioresponses) -> None:
     # need to use an absolute URL.
     new_url = get_data_url('direct.alias')
     mock_aioresponses.get(url, headers={'Location': new_url}, status=307)
-    for match in mock_aioresponses._matches:
-        print(match.method, match.url_or_pattern)
     with await fetch_aiohttp.fetch_model(url, DummyModel) as model:
         assert len(model.ranges) == 2
 

--- a/test/test_rfi_mask.py
+++ b/test/test_rfi_mask.py
@@ -52,7 +52,7 @@ def test_is_masked_scalar(frequency: u.Quantity, baseline_length: u.Quantity, re
     assert ranges_model.is_masked(frequency, baseline_length) == result
 
 
-def test_is_masked_vector(ranges_model):
+def test_is_masked_vector(ranges_model: rfi_mask.RFIMaskRanges):
     frequency = u.Quantity([90, 110, 90, 110, 300, 600, 600, 600], u.MHz)
     baseline_length = u.Quantity([2, 2, 2000, 2000, 2, 2, 2000, 0], u.m)
     result = ranges_model.is_masked(frequency, baseline_length)
@@ -61,6 +61,13 @@ def test_is_masked_vector(ranges_model):
     # Test broadcasting of inputs against each other
     result = ranges_model.is_masked(frequency, 2 * u.m)
     expected = np.array([False, True, False, True, False, True, True, True])
+    np.testing.assert_array_equal(result, expected)
+
+
+def test_is_masked_channel_bandwidth(ranges_model: rfi_mask.RFIMaskRanges):
+    frequency = u.Quantity([70, 90, 110, 190, 210, 230], u.MHz)
+    result = ranges_model.is_masked(frequency, 1 * u.m, 20 * u.MHz)
+    expected = np.array([False, True, True, True, True, False])
     np.testing.assert_array_equal(result, expected)
 
 
@@ -90,6 +97,15 @@ def test_max_baseline_length_vector(ranges_model: rfi_mask.RFIMask) -> None:
     np.testing.assert_array_equal(
         result.to_value(u.m),
         [-1, 1000, -1, np.inf, -1]
+    )
+
+
+def test_max_baseline_length_channel_width(ranges_model: rfi_mask.RFIMask) -> None:
+    frequency = u.Quantity([70, 90, 110, 190, 210, 230, 470, 490], u.MHz)
+    result = ranges_model.max_baseline_length(frequency, 20 * u.MHz)
+    np.testing.assert_array_equal(
+        result.to_value(u.m),
+        [-1, 1000, 1000, 1000, 1000, -1, -1, np.inf]
     )
 
 


### PR DESCRIPTION
This allows channels to be masked if any part of the channel is in the
masked range, instead of just checking the centre frequency.

Addresses SPR1-740, although dependent packages will need to be updated
to pass the parameter (it currently defaults to 0 for backwards
compatibility).