### PR TITLE
Update user documentation

### DIFF
--- a/doc/user/example_aliases1.tex
+++ b/doc/user/example_aliases1.tex
@@ -14,11 +14,11 @@
 \node[file, on chain] (s3-current) {current/m012/u.alias};
 \node[file, on chain, join] (s3-config) {config/m012/u/rx17.alias};
 \node[file, on chain, join] (s3-fixed) {fixed/sha256_0ae\ldots b9.h5};
-\node[fit={(s3-current) (s3-config) (s3-fixed)}, draw, label={S3}] {};
+\node[fit={(s3-current) (s3-config) (s3-fixed)}, draw, label={Model store}] {};
 
 \node[right=of s3-config, start chain=ts going below, on chain] (ts-latest) {
-    \ldots m012.model.primary_beam.config};
-\node[on chain=ts] (ts-fixed) {\ldots m012.model.primary_beam.fixed};
+    \ldots m012_model_primary_beam_config};
+\node[on chain=ts] (ts-fixed) {\ldots m012_model_primary_beam_fixed};
 \node[fit={(ts-latest) (ts-fixed)}, draw, label=Telstate] {};
 \draw[link] (ts-latest) -- (s3-config);
 \draw[link] (ts-fixed) -- (s3-fixed);

--- a/doc/user/example_aliases2.tex
+++ b/doc/user/example_aliases2.tex
@@ -16,11 +16,12 @@
 \node[file, on chain] (s3-fixed) {fixed/sha256_0ae\ldots b9.h5};
 \node[file, on chain=going left, join=with s3-config] (s3-fixed-new)
   {fixed/sha256_d71\ldots 0a.h5};
-\node[fit={(s3-current) (s3-config) (s3-fixed) (s3-fixed-new)}, draw, label={S3}] {};
+\node[fit={(s3-current) (s3-config) (s3-fixed) (s3-fixed-new)},
+      draw, label={Model store}] {};
 
 \node[right=of s3-config, start chain=ts going below, on chain] (ts-latest) {
-    \ldots m012.model.primary_beam.config};
-\node[on chain=ts] (ts-fixed) {\ldots m012.model.primary_beam.fixed};
+    \ldots m012_model_primary_beam_config};
+\node[on chain=ts] (ts-fixed) {\ldots m012_model_primary_beam_fixed};
 \node[fit={(ts-latest) (ts-fixed)}, draw, label=Telstate] {};
 \draw[link] (ts-latest) -- (s3-config);
 \draw[link] (ts-fixed) -- (s3-fixed);

--- a/doc/user/example_aliases3.tex
+++ b/doc/user/example_aliases3.tex
@@ -23,11 +23,11 @@
 \draw[link] (s3-current) -- (s3-config-new);
 \draw[link] (s3-config-new) -- (s3-fixed-new2);
 \node[fit={(s3-current) (s3-config) (s3-fixed) (s3-fixed-new)
-           (s3-config-new) (s3-fixed-new2)}, draw, label={S3}] {};
+           (s3-config-new) (s3-fixed-new2)}, draw, label={Model store}] {};
 
 \node[right=of s3-config, start chain=ts going below, on chain] (ts-latest) {
-    \ldots m012.model.primary_beam.config};
-\node[on chain=ts] (ts-fixed) {\ldots m012.model.primary_beam.fixed};
+    \ldots m012_model_primary_beam_config};
+\node[on chain=ts] (ts-fixed) {\ldots m012_model_primary_beam_fixed};
 \node[fit={(ts-latest) (ts-fixed)}, draw, label=Telstate] {};
 \draw[link] (ts-latest) -- (s3-config);
 \draw[link] (ts-fixed) -- (s3-fixed);

--- a/doc/user/formats.rst
+++ b/doc/user/formats.rst
@@ -4,7 +4,7 @@ Model file formats
 Models are stored in HDF5 files. Where boolean or complex values are stored,
 they use the conventions set by `h5py`_. The extension should be :file:`.h5`
 (:file:`.hdf5` is also accepted by this package). When served over HTTP, the
-``Content-Type`` should be ``application/x-hdf5``. 
+``Content-Type`` should be ``application/x-hdf5``.
 
 .. _h5py: https://docs.h5py.org/en/stable/
 
@@ -15,8 +15,7 @@ have a new checksum. The filename should thus be
 :samp:`{algorithm}` is ``sha256``. The package verifies the checksum if it is
 recognised, but using a filename without a checksum is not an error.
 
-Alternatively, a model with an extension of :file:`.alias` or a
-``Content-Type``
+Alternatively, a model with an extension of :file:`.alias` or ``Content-Type``
 of ``text/plain`` is an :dfn:`alias`. It must contain a relative path to the
 actual model. Aliases can also point at other aliases, but there is an
 implementation-defined maximum redirection depth. Aliases may not change
@@ -36,16 +35,22 @@ model_type
 
 model_format
     Indicates how the model is encoded in the file, and is specific to each
-    model type. This value also serves as a major version number: if
-    backwards-incompatible changes are made, a new ``model_format`` must be used.
-    There is no minor version numbering; just add new datasets, attributes
-    etc.
+    model type. If backwards-incompatible changes are made to the format, a
+    new ``model_format`` must be used. On the other hand, an existing format
+    may be extended with new datasets, attributes, etc. while maintaining
+    backwards compatibility.
+
+model_version
+    Simple integer version of the model for a particular configuration,
+    incremented only when semantic content changes to the model occur. Thus,
+    ``model_format`` may be updated without changing this version, provided
+    that the new parameters describe the same model.
 
 model_target (optional)
-    Human-readable string describing the target of the model. Note that
-    because models may be shared (e.g., multiple receptors may have the same
-    SEFD model), this might be more general than the target the user
-    requested.
+    Human-readable string describing the applicable targets and / or
+    configurations of the model. Note that because models may be shared
+    (e.g., multiple receptors may have the same SEFD model), this might be
+    more general than the target the user requested.
 
 model_comment (optional)
     Human-readable string which may describe the provenance of the model or
@@ -54,12 +59,7 @@ model_comment (optional)
 model_created (optional)
     Timestamp at which the model was created, in RFC 3339 format.
 
-model_version:
-    Simple integer version, incremented only when semantic content changes to
-    the model occur. Thus, ``model_format`` may be updated without changing
-    this version, provided that the new parameters describe the same model.
-
-model_author (optional):
+model_author (optional)
     Name of the person who created the model. It may optionally include an
     email address in angle brackets (name-addr format in RFC 2822).
 

--- a/doc/user/formats.rst
+++ b/doc/user/formats.rst
@@ -110,10 +110,10 @@ occur after down-conversion in a heterodyne system.
 Attributes
 ^^^^^^^^^^
 model_type
-    band_mask
+    ``band_mask``
 
 model_format
-    ranges
+    ``ranges``
 
 Datasets
 ^^^^^^^^

--- a/doc/user/structure.rst
+++ b/doc/user/structure.rst
@@ -17,11 +17,12 @@ Models are arranged in three levels, connected by alias files:
 3. For each target, the alias for the current configuration is pointed to by
    :samp:`{model_type}/current/{target}.alias`.
 
-The :samp:`{target}` may contain multiple components separated by slashes.
-It may also be empty, in which case the current alias is named
-:samp:`{model_type}/current.alias`. The :samp:`{config}` is intended to be a
-flat version string for the configuration. See :doc:`telstate` for an example
-of how these aliases point to each other.
+The :samp:`{target}` may contain multiple components separated by slashes. It
+may also be empty for telescope-level models, in which case the level 2 alias
+becomes :samp:`{model_type}/config/{config}.alias` and the level 3 alias
+becomes :samp:`{model_type}/current.alias`. The :samp:`{config}` is intended
+to be a flat version string for the configuration. See :doc:`telstate` for an
+example of how these aliases point to each other.
 
 Below, we list the naming conventions currently in use for MeerKAT for
 :samp:`{target}` and :samp:`{config}`. Other telescopes will likely use
@@ -31,7 +32,7 @@ range of targets, so are not expected to use the same naming conventions.
 RFI mask
 --------
 target
-    None
+    Empty string (i.e. a telescope-level model)
 
 config
     ``meerkat``
@@ -39,7 +40,7 @@ config
 Band mask
 ---------
 target
-    :samp:`{band}/nb_ratio={ratio}`, where :samp:`band` is the single-letter
+    :samp:`{band}/nb_ratio={ratio}`, where :samp:`{band}` is the single-letter
     abbreviation for the receiver band (``l``, ``s``, ``u`` or ``x`` in
     MeerKAT) and :samp:`{ratio}` is the integer ratio between the digitised
     bandwidth and the output correlator bandwidth. It is 1 for a wideband

--- a/doc/user/structure.rst
+++ b/doc/user/structure.rst
@@ -32,7 +32,7 @@ range of targets, so are not expected to use the same naming conventions.
 RFI mask
 --------
 target
-    Empty string (i.e. a telescope-level model)
+    None
 
 config
     ``meerkat``

--- a/doc/user/telstate.rst
+++ b/doc/user/telstate.rst
@@ -7,7 +7,7 @@ be retrieved later.
 
 .. _katsdptelstate: https://katsdptelstate.readthedocs.io
 
-The telescope state contains a ``sdp_model_base_url`` attribute which holds
+The telescope state contains an ``sdp_model_base_url`` attribute which holds
 a base URL for the models. All other URLs in the telescope state are relative
 to this. For each model used there are two entries in the telescope state. One
 has the suffix ``fixed`` and references the exact model that was current
@@ -49,7 +49,7 @@ situation:
    :include: example_aliases2.tex
 
 The telescope state has not been altered, but by using the
-primary_beam_model_latest key, one can access the improved model, without
+``model_primary_beam_config`` key, one can access the improved model, without
 losing track of the model that was used online.
 
 Next, suppose the receiver on m012 was swapped out for a different one. Then
@@ -80,10 +80,10 @@ In future `katdal`_ may be updated to hide these details and allow models to
 be fetched directly from a katdal data set. Until then, one can obtain the
 underlying telescope state object from a dataset as
 ``dataset.source.telstate``. Pass it to the constructor of
-:class:`katsdpmodels.fetch.aiohttp.TelescopeStateFetch` (asynchronous) or
-:class:`katsdpmodels.fetch.requests.TelescopeStateFetch` (synchronous), along
+:class:`katsdpmodels.fetch.aiohttp.TelescopeStateFetcher` (asynchronous) or
+:class:`katsdpmodels.fetch.requests.TelescopeStateFetcher` (synchronous), along
 with an (optional) underlying fetcher. Then use
-:meth:`~katsdpmodelsf.etch.requests.TelescopeStateFetch.get` to retrieve
+:meth:`~katsdpmodels.fetch.requests.TelescopeStateFetcher.get` to retrieve
 models. Instead of passing an URL (as for the underlying fetcher classes),
 pass the name of the telescope state key holding the relative URL.
 
@@ -92,17 +92,17 @@ pass the name of the telescope state key holding the relative URL.
 In some cases one may wish to look up the key within a telescope state view.
 This can be done by passing the view as a ``telstate`` keyword argument. Here
 is an example of fetching a band mask model from a view called
-``telstate_cbf`` which refers to the antenna-channelised-voltage stream:
+``telstate_cbf`` which refers to the ``antenna-channelised-voltage`` stream:
 
 .. code:: python
 
-    band_mask_model_key = telstate_cbf.join('model', 'band_mask', 'fixed')
-    try:
-        band_mask_model = await fetcher.get(band_mask_model_key,
-                                            katsdpmodels.band_mask.BandMask,
-                                            telstate=telstate_cbf)
-        return band_mask_model
-    except (aiohttp.ClientError, katsdpmodels.models.ModelError) as exc:
-        logger.warning('Failed to load band_mask model: %s', exc)
-        return None
-
+    with katsdpmodels.fetch.aiohttp.TelescopeStateFetcher(telstate) as fetcher:
+        band_mask_model_key = telstate_cbf.join('model', 'band_mask', 'fixed')
+        try:
+            band_mask_model = await fetcher.get(band_mask_model_key,
+                                                katsdpmodels.band_mask.BandMask,
+                                                telstate=telstate_cbf)
+            return band_mask_model
+        except (aiohttp.ClientError, katsdpmodels.models.ModelError) as exc:
+            logger.warning('Failed to load band_mask model: %s', exc)
+            return None


### PR DESCRIPTION
- Try to clarify `model_format` (does not serve as a version)
- Try to clarify `model_version` (it's the version of a configuration)
- Try to clarify `model_target` (not there yet...)
- Fix alias examples (external users don't know S3 and telstate separator is unfortunately not '.' 😢 )
- Clarify aliases for empty targets (telescope-level models)
- Various style and code reference fixes
- Try to expand the code example a bit to include fetcher creation