### PR TITLE
Revert "Use a negative length to indicate non-masked baselines"

### DIFF
--- a/src/katsdpmodels/rfi_mask.py
+++ b/src/katsdpmodels/rfi_mask.py
@@ -51,11 +51,15 @@ class RFIMask(models.SimpleHDF5Model):
 
     def max_baseline_length(self, frequency: u.Quantity,
                             channel_bandwidth: u.Quantity = 0 * u.Hz) -> Any:
-        """Determine maximum baseline length for which data at `frequency` should be masked.
+        """Maximum non-zero baseline length for which data should be masked.
 
-        If the frequency is not masked at all, returns 0.0, and if it is masked
-        at all baseline lengths, returns +inf. One may also supply an array of
-        frequencies and receive an array of responses.
+        If cross-correlations in the spectral channel with centre `frequency`
+        and width `channel_bandwidth` are not masked at all, returns 0.0,
+        and if they are masked at all baseline lengths, returns +inf. One may
+        also supply an array of frequencies and receive an array of responses.
+
+        Auto-correlations with zero baseline length are handled by
+        :meth:`mask_auto_correlations` instead.
         """
         raise NotImplementedError()      # pragma: nocover
 

--- a/src/katsdpmodels/rfi_mask.py
+++ b/src/katsdpmodels/rfi_mask.py
@@ -53,9 +53,9 @@ class RFIMask(models.SimpleHDF5Model):
                             channel_bandwidth: u.Quantity = 0 * u.Hz) -> Any:
         """Determine maximum baseline length for which data at `frequency` should be masked.
 
-        If the frequency is not masked at all, returns a negative length, and
-        if it is masked at all baseline lengths, returns +inf. One may also
-        supply an array of frequencies and receive an array of responses.
+        If the frequency is not masked at all, returns 0.0, and if it is masked
+        at all baseline lengths, returns +inf. One may also supply an array of
+        frequencies and receive an array of responses.
         """
         raise NotImplementedError()      # pragma: nocover
 
@@ -131,7 +131,7 @@ class RFIMaskRanges(RFIMask):
         b = np.broadcast_to(self.ranges['max_baseline'], in_range.shape, subok=True)
         return np.max(b,
                       axis=-1, where=in_range,
-                      initial=-1.0 * self.ranges['max_baseline'].unit)
+                      initial=0.0 * self.ranges['max_baseline'].unit)
 
     @classmethod
     def from_hdf5(cls: Type[_R], hdf5: h5py.File) -> _R:

--- a/test/test_rfi_mask.py
+++ b/test/test_rfi_mask.py
@@ -79,11 +79,11 @@ def test_is_masked_auto_correlations(ranges_model: rfi_mask.RFIMaskRanges) -> No
 @pytest.mark.parametrize(
     'frequency,result',
     [
-        (90e6 * u.Hz, -1 * u.m),
-        (90 * u.MHz, -1 * u.m),
+        (90e6 * u.Hz, 0 * u.m),
+        (90 * u.MHz, 0 * u.m),
         (110e6 * u.Hz, 1000 * u.m),
         (110 * u.MHz, 1000 * u.m),
-        (300 * u.MHz, -1 * u.m),
+        (300 * u.MHz, 0 * u.m),
         (600 * u.MHz, np.inf * u.m)
     ])
 def test_max_baseline_length_scalar(frequency: u.Quantity, result: u.Quantity,
@@ -96,7 +96,7 @@ def test_max_baseline_length_vector(ranges_model: rfi_mask.RFIMask) -> None:
     result = ranges_model.max_baseline_length(frequency)
     np.testing.assert_array_equal(
         result.to_value(u.m),
-        [-1, 1000, -1, np.inf, -1]
+        [0, 1000, 0, np.inf, 0]
     )
 
 
@@ -111,9 +111,9 @@ def test_max_baseline_length_channel_width(ranges_model: rfi_mask.RFIMask) -> No
 
 def test_max_baseline_length_empty(ranges_model: rfi_mask.RFIMaskRanges) -> None:
     ranges_model.ranges.remove_rows(np.s_[:])
-    assert ranges_model.max_baseline_length(1 * u.Hz) == -1 * u.m
+    assert ranges_model.max_baseline_length(1 * u.Hz) == 0 * u.m
     result = ranges_model.max_baseline_length([1, 2] * u.Hz)
-    np.testing.assert_array_equal(result.to_value(u.m), [-1.0, -1.0])
+    np.testing.assert_array_equal(result.to_value(u.m), [0.0, 0.0])
 
 
 @pytest.mark.parametrize(

--- a/test/test_rfi_mask.py
+++ b/test/test_rfi_mask.py
@@ -105,7 +105,7 @@ def test_max_baseline_length_channel_width(ranges_model: rfi_mask.RFIMask) -> No
     result = ranges_model.max_baseline_length(frequency, 20 * u.MHz)
     np.testing.assert_array_equal(
         result.to_value(u.m),
-        [-1, 1000, 1000, 1000, 1000, -1, -1, np.inf]
+        [0, 1000, 1000, 1000, 1000, 0, 0, np.inf]
     )
 
 


### PR DESCRIPTION
Reverts #6.

The use of negative lengths to indicate no masking creates the potential for more confusion for me.

We now have an explicit `mask_auto_correlations` field (since #7...). I contend that `max_baseline_length` should therefore not apply to autocorrelations. Otherwise you might get the contradictory situation of `max_baseline_length = 0` and `mask_auto_correlations = False` (answer: it's not masked).

One way to ensure this is to go back to the old behaviour where 0 baseline length is special (= no mask) and therefore not applicable to autocorrelations. The upside of this is that all client code will still work, since they generally check that `max_baseline_length > 0` and not `max_baseline_length >= 0`.

Add some documentation to make this clear.