### PR TITLE
Improve docs and API

### DIFF
--- a/doc/user/formats.rst
+++ b/doc/user/formats.rst
@@ -82,7 +82,7 @@ model_format
     ``ranges``
 
 mask_auto_correlations
-    A boolean to indicate whether autocorrelations (both same-hand and
+    A boolean to indicate whether auto-correlations (both same-hand and
     cross-hand) should be masked, in which case it is done for frequencies
     covered by any of the ranges.
 

--- a/doc/user/formats.rst
+++ b/doc/user/formats.rst
@@ -84,7 +84,10 @@ model_format
 mask_auto_correlations
     A boolean to indicate whether auto-correlations (both same-hand and
     cross-hand) should be masked, in which case it is done for frequencies
-    covered by any of the ranges.
+    covered by any of the ranges. That is, if this is ``False``, no
+    auto-correlations will be masked for RFI. If this is ``True``,
+    auto-correlations are considered to be very short (zero-length) baselines
+    and treated like any other baseline.
 
 Datasets
 ^^^^^^^^
@@ -97,7 +100,7 @@ ranges
 
     max_baseline (float)
         Maximum (inclusive) baseline length for which these frequencies should
-        be masked. To mask all baselines, use ∞.
+        be masked. This should be non-negative. To mask all baselines, use ∞.
 
 Band mask
 ---------

--- a/doc/user/formats.rst
+++ b/doc/user/formats.rst
@@ -87,7 +87,7 @@ mask_auto_correlations
     covered by any of the ranges. That is, if this is ``False``, no
     auto-correlations will be masked for RFI. If this is ``True``,
     auto-correlations are considered to be very short (zero-length) baselines
-    and treated like any other baseline.
+    and treated like any other baselines.
 
 Datasets
 ^^^^^^^^

--- a/setup.cfg
+++ b/setup.cfg
@@ -48,3 +48,7 @@ requests =
 aiohttp =
     aiohttp
     aiohttp-retry>=2.0
+
+[pylint.TYPECHECK]
+# These Astropy modules generate most of their members
+ignored-modules = astropy.units,astropy.constants

--- a/src/katsdpmodels/rfi_mask.py
+++ b/src/katsdpmodels/rfi_mask.py
@@ -38,24 +38,28 @@ class RFIMask(models.SimpleHDF5Model):
 
     def is_masked(self, frequency: u.Quantity, baseline_length: u.Quantity,
                   channel_width: u.Quantity = 0 * u.Hz) -> Any:
-        """Determine whether given frequency is masked for the given baseline length.
+        """Determine whether given frequency is masked for given baseline length.
 
-        The return value is either a boolean (if `frequency` and
-        `baseline_length` are scalar) or an array of boolean if they're arrays,
-        with the usual broadcasting rules applying.
+        The return value is either a boolean (if `frequency`, `baseline_length`
+        and `channel_width` are scalar) or an array of boolean if they're
+        arrays, with the usual broadcasting rules applying.
 
         A channel is masked if any part of the channel overlaps with RFI. The
-        channel has width `channel_width` and is centred on `frequency`.
+        channel has width `channel_width` and is centred on `frequency`. This
+        also honours the :attr:`mask_auto_correlations` property for baseline
+        lengths of zero.
         """
         raise NotImplementedError()      # pragma: nocover
 
     def max_baseline_length(self, frequency: u.Quantity,
                             channel_width: u.Quantity = 0 * u.Hz) -> Any:
-        """Determine maximum baseline length for which data at `frequency` should be masked.
+        """Maximum baseline length for which data at `frequency` should be masked.
 
         If the frequency is not masked at all, returns a negative length, and
         if it is masked at all baseline lengths, returns +inf. One may also
-        supply an array of frequencies and receive an array of responses.
+        supply an array of frequencies and receive an array of responses. This
+        does *not* include the effect of the :attr:`mask_auto_correlations`
+        property when returning a value of zero.
         """
         raise NotImplementedError()      # pragma: nocover
 
@@ -64,7 +68,11 @@ class RFIMask(models.SimpleHDF5Model):
         """Return whether auto-correlations should be masked too.
 
         Auto-correlations are defined as baselines with zero length, which
-        includes cross-hand polarization products.
+        includes cross-hand polarisation products. This property indicates
+        whether auto-correlations should be masked, in which case it is done
+        for frequencies covered by any of the ranges. That is, if this is
+        `False`, no auto-correlations will be masked for RFI. If this is
+        `True`, auto-correlations are treated like any other baseline.
         """
         raise NotImplementedError()      # pragma: nocover
 

--- a/src/katsdpmodels/rfi_mask.py
+++ b/src/katsdpmodels/rfi_mask.py
@@ -72,7 +72,7 @@ class RFIMask(models.SimpleHDF5Model):
         whether auto-correlations should be masked, in which case it is done
         for frequencies covered by any of the ranges. That is, if this is
         `False`, no auto-correlations will be masked for RFI. If this is
-        `True`, auto-correlations are treated like any other baseline.
+        `True`, auto-correlations are treated like any other baselines.
         """
         raise NotImplementedError()      # pragma: nocover
 

--- a/src/katsdpmodels/rfi_mask.py
+++ b/src/katsdpmodels/rfi_mask.py
@@ -37,7 +37,7 @@ class RFIMask(models.SimpleHDF5Model):
     # https://github.com/python/mypy/issues/4717
 
     def is_masked(self, frequency: u.Quantity, baseline_length: u.Quantity,
-                  channel_bandwidth: u.Quantity = 0 * u.Hz) -> Any:
+                  channel_width: u.Quantity = 0 * u.Hz) -> Any:
         """Determine whether given frequency is masked for the given baseline length.
 
         The return value is either a boolean (if `frequency` and
@@ -45,12 +45,12 @@ class RFIMask(models.SimpleHDF5Model):
         with the usual broadcasting rules applying.
 
         A channel is masked if any part of the channel overlaps with RFI. The
-        channel has width `channel_bandwidth` and is centred on `frequency`.
+        channel has width `channel_width` and is centred on `frequency`.
         """
         raise NotImplementedError()      # pragma: nocover
 
     def max_baseline_length(self, frequency: u.Quantity,
-                            channel_bandwidth: u.Quantity = 0 * u.Hz) -> Any:
+                            channel_width: u.Quantity = 0 * u.Hz) -> Any:
         """Determine maximum baseline length for which data at `frequency` should be masked.
 
         If the frequency is not masked at all, returns a negative length, and

--- a/test/test_rfi_mask.py
+++ b/test/test_rfi_mask.py
@@ -64,7 +64,7 @@ def test_is_masked_vector(ranges_model: rfi_mask.RFIMaskRanges):
     np.testing.assert_array_equal(result, expected)
 
 
-def test_is_masked_channel_bandwidth(ranges_model: rfi_mask.RFIMaskRanges):
+def test_is_masked_channel_width(ranges_model: rfi_mask.RFIMaskRanges):
     frequency = u.Quantity([70, 90, 110, 190, 210, 230], u.MHz)
     result = ranges_model.is_masked(frequency, 1 * u.m, 20 * u.MHz)
     expected = np.array([False, True, True, True, True, False])


### PR DESCRIPTION
I standardised on `channel_width` (instead of `channel_bandwidth`) and `auto-correlations` (instead of `autocorrelations`). The latter is purely because there is a property called `mask_auto_correlations`. Don't worry, even [Wikipedia](https://en.wikipedia.org/wiki/Autocorrelation) can't seem to decide on this.

And then I hopefully added some useful extra bits of documentation - embellishments for my benefit that hopefully don't contradict the original version.