### PR TITLE
Implement primary beam functionality

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,2 +1,5 @@
 [flake8]
 max-line-length = 100
+# E741 ambiguous variable name 'l'
+# W503 line break before binary operator
+ignore = E741, W503

--- a/.flake8
+++ b/.flake8
@@ -1,5 +1,6 @@
 [flake8]
 max-line-length = 100
+# E203 whitespace before ':'
 # E741 ambiguous variable name 'l'
 # W503 line break before binary operator
-ignore = E741, W503
+ignore = E203, E741, W503

--- a/doc/user/formats.rst
+++ b/doc/user/formats.rst
@@ -200,8 +200,8 @@ frequency
 aperture_plane
     5D array, with axes corresponding to (in order)
 
+    - frequency
     - row of Jones matrix (length 2)
     - column of Jones matrix (length 2)
-    - frequency
     - y
     - x

--- a/doc/user/formats.rst
+++ b/doc/user/formats.rst
@@ -195,7 +195,7 @@ specification (and this package does not do any such checks itself).
 Datasets
 ^^^^^^^^
 frequency
-    1D array of sampled frequencies.
+    1D array of sampled frequencies. It must be strictly increasing.
 
 aperture_plane
     5D array, with axes corresponding to (in order)

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,9 @@ aiohttp
 aiohttp-retry
 astropy
 h5py
+numba
 numpy
 requests
+scipy
 strict-rfc3339
 typing-extensions

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,9 +18,11 @@ package_dir =
     = src
 packages = find:
 install_requires =
-    numpy
     astropy
     h5py >= 2.9
+    numba
+    numpy
+    scipy
     strict_rfc3339
     typing_extensions
 python_requires = >=3.6

--- a/src/katsdpmodels/models.py
+++ b/src/katsdpmodels/models.py
@@ -285,12 +285,14 @@ class SimpleHDF5Model(Model):
 
 @overload
 def get_hdf5_attr(attrs: Mapping[str, object], name: str, required_type: Type[_T], *,
-                  required: Literal[True]) -> _T: ...
+                  required: Literal[True]) -> _T:
+    ...
 
 
 @overload
 def get_hdf5_attr(attrs: Mapping[str, object], name: str, required_type: Type[_T], *,
-                  required: bool = False) -> Optional[_T]: ...
+                  required: bool = False) -> Optional[_T]:
+    ...
 
 
 def get_hdf5_attr(attrs, name, required_type, *, required=False):

--- a/src/katsdpmodels/models.py
+++ b/src/katsdpmodels/models.py
@@ -27,6 +27,10 @@ from typing_extensions import Literal
 import h5py
 import numpy as np
 import numpy.lib.recfunctions
+try:
+    from numpy.typing import DTypeLike
+except ImportError:
+    DTypeLike = Any  # type: ignore
 import strict_rfc3339
 
 
@@ -355,12 +359,14 @@ def rfc3339_to_datetime(timestamp: str) -> datetime:
     return datetime.fromtimestamp(unix_time, timezone.utc)
 
 
-def require_columns(name: str, array: Any, dtype: np.dtype, ndim: int) -> Any:
+def require_columns(name: str, array: Any, dtype: DTypeLike, ndim: int) -> Any:
     """Validate the columns in a table and the dimensionality.
 
-    The `dtype` is the expected dtype, which must be a structured dtype. The
+    The `dtype` is the expected dtype, which may be a structured dtype. The
     array is checked for compatibility: it must have all the required fields
     (but may have more), and they must be castable to the the expected dtype.
+    Alternatively, if `dtype` is non-structured, the array must have a dtype
+    that can be cast. In both cases, 'same_kind' casting is required.
 
     The return value is the input array restricted to the required columns
     and cast to the required dtype. It may be either a view or a copy,
@@ -374,14 +380,19 @@ def require_columns(name: str, array: Any, dtype: np.dtype, ndim: int) -> Any:
     DataError
         if the types are not compatible or the wrong number of dimensions are present.
     """
+    dtype = np.dtype(dtype)
     # The type: ignore statements below are due to https://github.com/numpy/numpy/issues/18597
     if array.ndim != ndim:
         raise DataError(f'{name} should be {ndim}-dimensional, but is {array.ndim}-dimensional')
     if array.dtype == dtype:
         return np.asanyarray(array)
+    if dtype.names is None:
+        if not np.can_cast(array.dtype, dtype, 'same_kind'):
+            raise DataError(
+                f'{name} has type {array.dtype}, expected {dtype}')
+        return array.astype(dtype, copy=False)
     if array.dtype.names is None:
         raise DataError(f'{name} does not have named columns')
-    assert dtype.names is not None, "dtype must be a structured dtype"
     for col_name in dtype.names:
         if col_name not in array.dtype.names:
             raise DataError(f'{name} column {col_name} is missing')

--- a/src/katsdpmodels/models.py
+++ b/src/katsdpmodels/models.py
@@ -390,7 +390,7 @@ def require_columns(name: str, array: Any, dtype: DTypeLike, ndim: int) -> Any:
         if not np.can_cast(array.dtype, dtype, 'same_kind'):
             raise DataError(
                 f'{name} has type {array.dtype}, expected {dtype}')
-        return array.astype(dtype, copy=False)
+        return array.astype(dtype)
     if array.dtype.names is None:
         raise DataError(f'{name} does not have named columns')
     for col_name in dtype.names:

--- a/src/katsdpmodels/primary_beam.py
+++ b/src/katsdpmodels/primary_beam.py
@@ -653,6 +653,10 @@ class PrimaryBeamAperturePlane(PrimaryBeam):
             y = y_m * wavenumber[freq_idx]
             coeff1 = _expjm2pi(np.outer(l, x))
             coeff2 = _expjm2pi(np.outer(m, y))
+            # Shove the polarizations into extra columns in a matrix. Matrix
+            # multiplication treats the columns in the RHS independently,
+            # which is what we want for polarizations, and the result then
+            # has the right memory layout.
             tmp = np.zeros((len(y), len(l) * 4), np.complex64)
             s = samples[freq_idx]
             for i in range(2):

--- a/src/katsdpmodels/primary_beam.py
+++ b/src/katsdpmodels/primary_beam.py
@@ -358,16 +358,17 @@ def _asarray(x: ArrayLike, dtype: Optional[DTypeLike] = None) -> np.ndarray:
     When a dtype is specified, uses ``same_kind`` casting.
     """
     if isinstance(x, u.Quantity):
-        x = x.to_value(u.dimensionless_unscaled)
+        array = x.to_value(u.dimensionless_unscaled)
     else:
-        x = np.asarray(x)
+        array = np.asarray(x)
     if dtype is not None:
-        x = x.astype(dtype, copy=False, casting='same_kind')
-    return x
+        array = array.astype(dtype, copy=False, casting='same_kind')
+    return array
 
 
 def _check_out(out: Optional[np.ndarray], output_type: OutputType) -> None:
     if out is not None:
+        expected_dtype: np.dtype
         if output_type != OutputType.UNPOLARIZED_POWER:
             expected_dtype = np.dtype(np.complex64)
         else:
@@ -426,12 +427,12 @@ class PrimaryBeamAperturePlane(PrimaryBeam):
         self._band = band
 
     @property
-    def x(self) -> np.ndarray:
+    def x(self) -> u.Quantity:
         """x coordinates associated with the samples."""
         return np.arange(self.samples.shape[-1]) * self.x_step + self.x_start
 
     @property
-    def y(self) -> np.ndarray:
+    def y(self) -> u.Quantity:
         """y coordinates associated with the samples."""
         return np.arange(self.samples.shape[-2]) * self.y_step + self.y_start
 

--- a/src/katsdpmodels/primary_beam.py
+++ b/src/katsdpmodels/primary_beam.py
@@ -627,8 +627,9 @@ class PrimaryBeamAperturePlane(PrimaryBeam):
             lm = np.stack([l_.ravel(), m_.ravel()], axis=0)
             # Convert to AltAz frame
             lm = frame.lm_to_hv() @ lm
-            # Unpack again: TODO: unravel
-            l_, m_ = lm
+            # Unpack again
+            l_ = lm[0].reshape(l_.shape)
+            m_ = lm[1].reshape(m_.shape)
         elif not isinstance(frame, AltAzFrame):
             raise TypeError(f'frame must be RADecFrame or AltAzFrame, not {type(frame)}')
         l_ = _asarray(l_, np.float32)

--- a/src/katsdpmodels/primary_beam.py
+++ b/src/katsdpmodels/primary_beam.py
@@ -433,9 +433,9 @@ class PrimaryBeamAperturePlane(PrimaryBeam):
             out = np.empty(out_shape, np.complex64)
         else:
             if out.shape != out_shape:
-                raise ValueError(f'out must be {out_shape}, not {out.shape}')
+                raise ValueError(f'out must have shape {out_shape}, not {out.shape}')
             if out.dtype != np.dtype(np.complex64):
-                raise TypeError('out must be complex64, not {out.dtype}')
+                raise TypeError(f'out must have dtype complex64, not {out.dtype}')
             if not out.flags.c_contiguous:
                 raise ValueError('out must be C contiguous')
 

--- a/src/katsdpmodels/primary_beam.py
+++ b/src/katsdpmodels/primary_beam.py
@@ -547,7 +547,7 @@ class PrimaryBeamAperturePlane(PrimaryBeam):
                 raise ValueError('JONES_XY required a RADecFrame')
             jones = frame.jones_hv_to_xy().astype(np.complex64)
         elif output_type != OutputType.JONES_HV:
-            raise NotImplementedError('Only JONES_HV is implemented so far')
+            raise NotImplementedError('Only JONES_HV and JONES_XY are implemented so far')
 
         out = self._sample_altaz(l_, m_, frequency, jones=jones, out=out)
 

--- a/src/katsdpmodels/primary_beam.py
+++ b/src/katsdpmodels/primary_beam.py
@@ -194,6 +194,13 @@ class PrimaryBeam(models.SimpleHDF5Model):
         """
         raise NotImplementedError()
 
+    @property
+    def band(self) -> Optional[str]:
+        """String identifier of the receiver band to which this model applies.
+
+        If not known, it will be ``None``.
+        """
+
     def sample(self, l: ArrayLike, m: ArrayLike, frequency: u.Quantity,   # noqa: E741
                frame: Union[AltAzFrame, RADecFrame],
                output_type: OutputType, *,
@@ -284,8 +291,10 @@ class PrimaryBeamAperturePlane(PrimaryBeam):
             x_start: u.Quantity, y_start: u.Quantity,
             x_step: u.Quantity, y_step: u.Quantity,
             frequencies: u.Quantity, samples: u.Quantity,
+            *,
             antenna: Optional[str] = None,
-            receiver: Optional[str] = None):
+            receiver: Optional[str] = None,
+            band: Optional[str] = None):
         super().__init__()
         # Canonicalise the units to simplify to_hdf5 (and also remove the
         # cost of conversions when methods are called with canonical units,
@@ -305,6 +314,7 @@ class PrimaryBeamAperturePlane(PrimaryBeam):
             self._frequency_resolution = 0 * u.Hz
         self._antenna = antenna
         self._receiver = receiver
+        self._band = band
 
     @property
     def x(self) -> np.ndarray:
@@ -355,6 +365,10 @@ class PrimaryBeamAperturePlane(PrimaryBeam):
     def receiver(self) -> Optional[str]:
         return self._receiver
 
+    @property
+    def band(self) -> Optional[str]:
+        return self._band
+
     @classmethod
     def from_hdf5(cls: Type[_P], hdf5: h5py.File) -> _P:
         samples = models.get_hdf5_dataset(hdf5, 'samples')
@@ -372,4 +386,5 @@ class PrimaryBeamAperturePlane(PrimaryBeam):
         y_step = models.get_hdf5_attr(hdf5, 'y_step', float, required=True) * u.m
         return cls(x_start, y_start, x_step, y_step, frequencies, samples,
                    antenna=models.get_hdf5_attr(hdf5, 'antenna', str),
-                   receiver=models.get_hdf5_attr(hdf5, 'receiver', str))
+                   receiver=models.get_hdf5_attr(hdf5, 'receiver', str),
+                   band=models.get_hdf5_attr(hdf5, 'band', str))

--- a/src/katsdpmodels/primary_beam.py
+++ b/src/katsdpmodels/primary_beam.py
@@ -586,6 +586,19 @@ class PrimaryBeamAperturePlane(PrimaryBeam):
         else:
             raise ValueError(f'Unrecognised output_type {output_type}')
 
+    def sample_grid(self, l: ArrayLike, m: ArrayLike, frequency: u.Quantity,   # noqa: E741
+                    frame: Union[AltAzFrame, RADecFrame],
+                    output_type: OutputType, *,
+                    out: Optional[np.ndarray] = None) -> np.ndarray:
+        # This is a completely unoptimised placeholder implementation.
+        l_ = np.asarray(l)
+        m_ = np.asarray(m)
+        if l_.ndim != 1 or m_.ndim != 1:
+            raise ValueError('l and m must be 1D')
+        return self.sample(
+            l_[np.newaxis, :], m_[:, np.newaxis], frequency,
+            frame, output_type, out=out)
+
     @classmethod
     def from_hdf5(cls: Type[_P], hdf5: h5py.File) -> _P:
         samples = models.get_hdf5_dataset(hdf5, 'aperture_plane')

--- a/src/katsdpmodels/primary_beam.py
+++ b/src/katsdpmodels/primary_beam.py
@@ -137,12 +137,12 @@ class PrimaryBeam(models.SimpleHDF5Model):
         diminishing returns compared to sampling at this resolution and
         interpolating.
         """
-        raise NotImplementedError()
+        raise NotImplementedError()      # pragma: nocover
 
     @property
     def frequency_range(self) -> Tuple[u.Quantity, u.Quantity]:
         """Minimum and maximum frequency covered by the model."""
-        raise NotImplementedError()
+        raise NotImplementedError()      # pragma: nocover
 
     @property
     def frequency_resolution(self) -> u.Quantity:
@@ -152,20 +152,20 @@ class PrimaryBeam(models.SimpleHDF5Model):
         have diminishing returns compared to sampling at this resolution and
         interpolating.
         """
-        raise NotImplementedError()
+        raise NotImplementedError()      # pragma: nocover
 
     def inradius(self, frequency: u.Quantity) -> float:
         """Maximum distance from the pointing centre at which model has full coverage."""
-        raise NotImplementedError()
+        raise NotImplementedError()      # pragma: nocover
 
     def circumradius(self, frequency: u.Quantity) -> float:
         """Maximum distance from the pointing centre at which model has any coverage."""
-        raise NotImplementedError()
+        raise NotImplementedError()      # pragma: nocover
 
     @property
     def is_circular(self) -> bool:
         """Whether this model is circularly-symmetric about the pointing centre."""
-        raise NotImplementedError()
+        raise NotImplementedError()      # pragma: nocover
 
     @property
     def is_unpolarized(self) -> bool:
@@ -174,7 +174,7 @@ class PrimaryBeam(models.SimpleHDF5Model):
         If true, it is guaranteed that the Jones matrices describing the beam are
         scaled identity matrices.
         """
-        raise NotImplementedError()
+        raise NotImplementedError()      # pragma: nocover
 
     @property
     def antenna(self) -> Optional[str]:
@@ -183,7 +183,7 @@ class PrimaryBeam(models.SimpleHDF5Model):
         If this model is not antenna-specific or does not carry this
         information, it will be ``None``.
         """
-        raise NotImplementedError()
+        raise NotImplementedError()      # pragma: nocover
 
     @property
     def receiver(self) -> Optional[str]:
@@ -192,7 +192,7 @@ class PrimaryBeam(models.SimpleHDF5Model):
         If this model is not specific to a single receiver or the model does
         not carry this information, it will be ``None``.
         """
-        raise NotImplementedError()
+        raise NotImplementedError()      # pragma: nocover
 
     @property
     def band(self) -> Optional[str]:
@@ -242,7 +242,7 @@ class PrimaryBeam(models.SimpleHDF5Model):
         astropy.units.UnitConversionError
             if `frequency` is not specified with a spectral unit
         """
-        raise NotImplementedError()
+        raise NotImplementedError()      # pragma: nocover
 
     def sample_grid(self, l: ArrayLike, m: ArrayLike, frequency: u.Quantity,   # noqa: E741
                     frame: Union[AltAzFrame, RADecFrame],
@@ -262,7 +262,7 @@ class PrimaryBeam(models.SimpleHDF5Model):
         Refer to :meth:`sample` for further details of the parameters and
         return value.
         """
-        raise NotImplementedError()
+        raise NotImplementedError()      # pragma: nocover
 
     @classmethod
     def from_hdf5(cls, hdf5: h5py.File) -> 'PrimaryBeam':
@@ -309,7 +309,7 @@ class PrimaryBeamAperturePlane(PrimaryBeam):
         if len(frequency) > 1:
             self._frequency_resolution = np.min(np.diff(frequency))
             if self._frequency_resolution <= 0 * u.Hz:
-                raise ValueError('Frequencies must be strictly increasing')
+                raise ValueError('frequencies must be strictly increasing')
         else:
             self._frequency_resolution = 0 * u.Hz
         self._antenna = antenna
@@ -379,9 +379,9 @@ class PrimaryBeamAperturePlane(PrimaryBeam):
         frequency = frequency[:]
         frequency <<= u.Hz
         if samples.shape[:2] != (2, 2):
-            raise models.DataError('aperture_plane must by 2x2 on leading dimensions')
+            raise ValueError('aperture_plane must by 2x2 on leading dimensions')
         if frequency.shape[0] != samples.shape[2]:
-            raise models.DataError('aperture_plane and frequency have inconsistent sizes')
+            raise ValueError('aperture_plane and frequency have inconsistent sizes')
         attrs = hdf5.attrs
         x_start = models.get_hdf5_attr(attrs, 'x_start', float, required=True) * u.m
         y_start = models.get_hdf5_attr(attrs, 'y_start', float, required=True) * u.m

--- a/src/katsdpmodels/primary_beam.py
+++ b/src/katsdpmodels/primary_beam.py
@@ -416,10 +416,10 @@ class PrimaryBeamAperturePlane(PrimaryBeam):
         if output_type != OutputType.JONES_HV:
             raise NotImplementedError('Only JONES_HV is implemented so far')
         # TODO: replace l/m with NaNs when out of range?
-        l = np.asarray(l).astype(np.float32, copy=False, casting='same_kind')
-        m = np.asarray(m).astype(np.float32, copy=False, casting='same_kind')
-        l, m = np.broadcast_arrays(l, m)
-        out_shape = frequency.shape + l.shape + (2, 2)
+        l_ = np.asarray(l).astype(np.float32, copy=False, casting='same_kind')
+        m_ = np.asarray(m).astype(np.float32, copy=False, casting='same_kind')
+        l_, m_ = np.broadcast_arrays(l_, m_)
+        out_shape = frequency.shape + l_.shape + (2, 2)
         if out is None:
             out = np.empty(out_shape, np.complex64)
         else:
@@ -442,11 +442,11 @@ class PrimaryBeamAperturePlane(PrimaryBeam):
         # l/m, so flatten. Assign to shape instead of reshape to ensure no
         # copying.
         out_view = out.view()
-        out_view.shape = frequency.shape + (l.size, 2, 2)
-        l = l.ravel()
-        m = m.ravel()
+        out_view.shape = frequency.shape + (l_.size, 2, 2)
+        l_ = l_.ravel()
+        m_ = m_.ravel()
         samples = self._interp_samples(frequency_Hz)
-        self._sample(samples, xf, yf, l, m, out_view)
+        self._sample(samples, xf, yf, l_, m_, out_view)
         return out
 
     @classmethod

--- a/src/katsdpmodels/primary_beam.py
+++ b/src/katsdpmodels/primary_beam.py
@@ -511,18 +511,20 @@ class PrimaryBeamAperturePlane(PrimaryBeam):
                frame: Union[AltAzFrame, RADecFrame],
                output_type: OutputType, *,
                out: Optional[np.ndarray] = None) -> np.ndarray:
+        l_ = np.asarray(l)
+        m_ = np.asarray(m)
         if isinstance(frame, RADecFrame):
-            l, m = np.broadcast_arrays(l, m)
+            l_, m_ = np.broadcast_arrays(l_, m_)
             # Form a matrix with just two rows
-            lm = np.stack([l.ravel(), m.ravel()], axis=0)
+            lm = np.stack([l_.ravel(), m_.ravel()], axis=0)
             # Convert to AltAz frame
             lm = frame.lm_to_hv() @ lm
             # Unpack again
-            l, m = lm
+            l_, m_ = lm
         elif not isinstance(frame, AltAzFrame):
             raise TypeError(f'frame must be RADecFrame or AltAzFrame, not {type(frame)}')
 
-        out = self._sample_hv(l, m, frequency, out=out)
+        out = self._sample_hv(l_, m_, frequency, out=out)
 
         if output_type != OutputType.JONES_HV:
             raise NotImplementedError('Only JONES_HV is implemented so far')

--- a/src/katsdpmodels/primary_beam.py
+++ b/src/katsdpmodels/primary_beam.py
@@ -580,9 +580,9 @@ class PrimaryBeamAperturePlane(PrimaryBeam):
             # Compute sum of squared magnitudes across the 4 Jones terms.
             # Viewing at float32 simplifies summing squared magnitudes.
             assert xy.dtype == np.dtype(np.complex64)
-            out = np.sum(np.square(xy.view(np.float32)), axis=(-2, -1), out=out)
-            out *= 0.5
-            return out
+            ret = np.sum(np.square(xy.view(np.float32)), axis=(-2, -1), out=out)
+            ret *= 0.5
+            return ret
         else:
             raise ValueError(f'Unrecognised output_type {output_type}')
 

--- a/test/test_models.py
+++ b/test/test_models.py
@@ -167,6 +167,19 @@ def test_require_columns_dimension_mismatch() -> None:
         models.require_columns('foo', array, dtype, 1)
 
 
+def test_require_columns_simple_mismatch() -> None:
+    with pytest.raises(models.DataError,
+                       match='foo has type float64, expected int32'):
+        models.require_columns('foo', np.zeros(3, np.float64), np.int32, 1)
+
+
+def test_require_columns_simple_castable() -> None:
+    array = np.array([1.0, 2.0, 3.0])
+    out = models.require_columns('foo', array, np.float32, 1)
+    np.testing.assert_array_equal(array, out)
+    assert out.dtype == np.dtype(np.float32)
+
+
 def assert_models_equal(model1: DummyModel, model2: DummyModel):
     assert type(model1) == type(model2)
     assert model1.model_type == model2.model_type

--- a/test/test_models.py
+++ b/test/test_models.py
@@ -32,8 +32,8 @@ from test_utils import DummyModel
 @pytest.fixture
 def dummy_model() -> DummyModel:
     ranges = np.array(
-       [(1, 4.5), (2, -5.5)],
-       dtype=[('a', 'i4'), ('b', 'f8')]
+        [(1, 4.5), (2, -5.5)],
+        dtype=[('a', 'i4'), ('b', 'f8')]
     )
     model = DummyModel(ranges)
     model.author = 'Test author'

--- a/test/test_primary_beam.py
+++ b/test/test_primary_beam.py
@@ -554,3 +554,19 @@ def test_sample_mueller(aperture_plane_model: primary_beam.PrimaryBeamAperturePl
     vis = np.tensordot(vis, primary_beam._XY_TO_IQUV, axes=((-1,), (-1,)))
 
     np.testing.assert_allclose(actual, vis, rtol=0, atol=1e-5)
+
+
+def test_sample_unpolarized_power(
+        aperture_plane_model: primary_beam.PrimaryBeamAperturePlane) -> None:
+    model = aperture_plane_model
+    l = [-0.002, 0.001, 0.0, 0.0, 0.0]
+    m = [0.0, 0.02, 0.0, -0.03, 0.01]
+    frequency = [1.25, 1.5] * u.GHz
+    frame = primary_beam.RADecFrame(parallactic_angle=30 * u.deg)
+
+    mueller = model.sample(
+        l, m, frequency, frame, primary_beam.OutputType.MUELLER)
+    unpol = model.sample(
+        l, m, frequency, frame, primary_beam.OutputType.UNPOLARIZED_POWER)
+
+    np.testing.assert_allclose(unpol, mueller[..., 0, 0], atol=1e-5)

--- a/test/test_primary_beam.py
+++ b/test/test_primary_beam.py
@@ -16,6 +16,8 @@
 
 """Tests for :mod:`katsdpmodels.primary_beam`"""
 
+import contextlib
+import pathlib
 from typing import Generator
 
 import astropy.units as u
@@ -23,17 +25,20 @@ import numpy as np
 import h5py
 import pytest
 
-from katsdpmodels import primary_beam
+from katsdpmodels import models, primary_beam
 import katsdpmodels.fetch.requests as fetch_requests
 
 
-def make_aperture_plane_model_file(h5file: h5py.File) -> None:
+@pytest.fixture
+def aperture_plane_model_file(tmp_path) -> h5py.File:
     """Create an aperture-plane model for testing.
 
     It writes the model directly rather than using the PrimaryBeam API
     to ensure the model adheres to the file format even if bugs are
     introduced into the API.
     """
+    path = tmp_path / 'aperture_plane_test.h5'
+    h5file = h5py.File(path, 'w')
     h5file.attrs['model_type'] = 'primary_beam'
     h5file.attrs['model_format'] = 'aperture_plane'
     h5file.attrs['model_comment'] = 'Dummy model for testing. Do not use in production.'
@@ -59,30 +64,21 @@ def make_aperture_plane_model_file(h5file: h5py.File) -> None:
     data[0, 0] += 1
     data[1, 1] += 1
     h5file.create_dataset('aperture_plane', data=data.astype(np.complex64))
+    return h5file
 
 
-@pytest.fixture
-def aperture_plane_model(tmp_path) \
-        -> Generator[primary_beam.PrimaryBeam, None, None]:
-    path = tmp_path / 'aperture_plane_test.h5'
-    with h5py.File(path, 'w') as h5file:
-        make_aperture_plane_model_file(h5file)
-    with fetch_requests.fetch_model(path.as_uri(),
-                                    primary_beam.PrimaryBeam) as model:
+@contextlib.contextmanager
+def serve_model(model_file: h5py.File) -> Generator[primary_beam.PrimaryBeam, None, None]:
+    path = pathlib.Path(model_file.filename)
+    model_file.close()  # Ensures data is written to the file
+    with fetch_requests.fetch_model(path.as_uri(), primary_beam.PrimaryBeam) as model:
         yield model
 
 
 @pytest.fixture
-def aperture_plane_model_no_optional(tmp_path) \
+def aperture_plane_model(aperture_plane_model_file) \
         -> Generator[primary_beam.PrimaryBeam, None, None]:
-    path = tmp_path / 'aperture_plane_test.h5'
-    with h5py.File(path, 'w') as h5file:
-        make_aperture_plane_model_file(h5file)
-        del h5file.attrs['receiver']
-        del h5file.attrs['antenna']
-        del h5file.attrs['band']
-    with fetch_requests.fetch_model(path.as_uri(),
-                                    primary_beam.PrimaryBeam) as model:
+    with serve_model(aperture_plane_model_file) as model:
         yield model
 
 
@@ -104,8 +100,70 @@ def test_properties(aperture_plane_model):
     assert model.band == 'z'
 
 
-def test_no_optional_properties(aperture_plane_model_no_optional):
-    model = aperture_plane_model_no_optional
-    assert model.antenna is None
-    assert model.receiver is None
-    assert model.band is None
+def test_no_optional_properties(aperture_plane_model_file):
+    h5file = aperture_plane_model_file
+    del h5file.attrs['receiver']
+    del h5file.attrs['antenna']
+    del h5file.attrs['band']
+    with serve_model(h5file) as model:
+        assert model.antenna is None
+        assert model.receiver is None
+        assert model.band is None
+
+
+def test_single_frequency(aperture_plane_model_file):
+    h5file = aperture_plane_model_file
+    old_frequency = h5file['frequency']
+    old_samples = h5file['aperture_plane']
+    del h5file['frequency']
+    del h5file['aperture_plane']
+    h5file.create_dataset('frequency', data=old_frequency[:1])
+    h5file.create_dataset('aperture_plane', data=old_samples[:, :, :1])
+    with serve_model(h5file) as model:
+        assert model.frequency_range() == (1000 * u.MHz, 1000 * u.MHz)
+        assert model.frequency_resolution() == 0
+
+
+def test_wrong_leading_dimensions(aperture_plane_model_file):
+    h5file = aperture_plane_model_file
+    del h5file['aperture_plane']
+    h5file.create_dataset('aperture_plane', shape=(3, 3, 64, 80, 40), dtype=np.complex64)
+    with pytest.raises(models.DataError, match='aperture_plane must by 2x2 on leading dimensions'):
+        with serve_model(h5file):
+            pass
+
+
+def test_frequency_bad_size(aperture_plane_model_file):
+    h5file = aperture_plane_model_file
+    old = h5file['frequency']
+    del h5file['frequency']
+    h5file.create_dataset('frequency', data=old[:-1])
+    with pytest.raises(models.DataError,
+                       match='aperture_plane and frequency have inconsistent sizes'):
+        with serve_model(h5file):
+            pass
+
+
+def test_frequency_bad_ordering(aperture_plane_model_file):
+    h5file = aperture_plane_model_file
+    h5file['frequency'][3] = 2e9
+    with pytest.raises(models.DataError, match='frequencies must be strictly increasing'):
+        with serve_model(h5file):
+            pass
+
+
+def test_missing_attr(aperture_plane_model_file):
+    h5file = aperture_plane_model_file
+    del h5file.attrs['x_start']
+    with pytest.raises(models.DataError, match="attribute 'x_start' is missing"):
+        with serve_model(h5file):
+            pass
+
+
+def test_bad_model_format(aperture_plane_model_file):
+    h5file = aperture_plane_model_file
+    h5file.attrs['model_format'] = 'not_this'
+    with pytest.raises(models.ModelFormatError,
+                       match="Unknown model_format 'not_this' for primary_beam"):
+        with serve_model(h5file):
+            pass

--- a/test/test_primary_beam.py
+++ b/test/test_primary_beam.py
@@ -244,7 +244,7 @@ def test_sample_interp_scalar_freq(
     np.testing.assert_allclose(actual[0], np.eye(2), rtol=0, atol=1e-6)
 
 
-def test_multi_dim_lm(aperture_plane_model: primary_beam.PrimaryBeamAperturePlane) -> None:
+def test_sample_multi_dim_lm(aperture_plane_model: primary_beam.PrimaryBeamAperturePlane) -> None:
     rs = np.random.RandomState()
     shape = (2, 3, 4)
     l = rs.random(shape) * 0.05
@@ -264,7 +264,7 @@ def test_multi_dim_lm(aperture_plane_model: primary_beam.PrimaryBeamAperturePlan
     assert not np.any(np.isnan(multi))
 
 
-def test_scalar_lm(aperture_plane_model: primary_beam.PrimaryBeamAperturePlane) -> None:
+def test_sample_scalar_lm(aperture_plane_model: primary_beam.PrimaryBeamAperturePlane) -> None:
     l = 0.01
     m = 0.02
     frequency = 1500 * u.MHz
@@ -281,7 +281,8 @@ def test_scalar_lm(aperture_plane_model: primary_beam.PrimaryBeamAperturePlane) 
     np.testing.assert_array_equal(scalar, vector[0])
 
 
-def test_frequency_array(aperture_plane_model: primary_beam.PrimaryBeamAperturePlane) -> None:
+def test_sample_frequency_array(
+        aperture_plane_model: primary_beam.PrimaryBeamAperturePlane) -> None:
     l = np.array([0.01])
     m = np.array([0.02])
     frequency = np.array([[1000, 1200], [1100, 1500]]) * u.MHz
@@ -303,7 +304,7 @@ def test_frequency_array(aperture_plane_model: primary_beam.PrimaryBeamApertureP
     np.testing.assert_array_equal(actual, expected)
 
 
-def test_lm_broadcast(aperture_plane_model: primary_beam.PrimaryBeamAperturePlane) -> None:
+def test_sample_lm_broadcast(aperture_plane_model: primary_beam.PrimaryBeamAperturePlane) -> None:
     l = np.array([0.01, 0.02])
     m = np.array([0.03, -0.04, 0.01])
     frequency = 1500 * u.MHz
@@ -337,7 +338,7 @@ def test_lm_broadcast(aperture_plane_model: primary_beam.PrimaryBeamAperturePlan
         (0.001, 0.002, 2000 * u.MHz)      # frequency too high
     ]
 )
-def test_out_of_range(
+def test_sample_out_of_range(
         aperture_plane_model: primary_beam.PrimaryBeamAperturePlane,
         l: float, m: float, frequency: u.Quantity) -> None:
     actual = aperture_plane_model.sample(
@@ -348,7 +349,7 @@ def test_out_of_range(
     np.testing.assert_array_equal(actual, expected)
 
 
-def test_partially_out_of_range(
+def test_sample_partially_out_of_range(
         aperture_plane_model: primary_beam.PrimaryBeamAperturePlane) -> None:
     model = aperture_plane_model
     l = [0.1, -0.19, 0.21]     # 0.2 is (roughly) the limit at 1.5 GHz

--- a/test/test_primary_beam.py
+++ b/test/test_primary_beam.py
@@ -1,0 +1,111 @@
+################################################################################
+# Copyright (c) 2021, National Research Foundation (SARAO)
+#
+# Licensed under the BSD 3-Clause License (the "License"); you may not use
+# this file except in compliance with the License. You may obtain a copy
+# of the License at
+#
+#   https://opensource.org/licenses/BSD-3-Clause
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+"""Tests for :mod:`katsdpmodels.primary_beam`"""
+
+from typing import Generator
+
+import astropy.units as u
+import numpy as np
+import h5py
+import pytest
+
+from katsdpmodels import primary_beam
+import katsdpmodels.fetch.requests as fetch_requests
+
+
+def make_aperture_plane_model_file(h5file: h5py.File) -> None:
+    """Create an aperture-plane model for testing.
+
+    It writes the model directly rather than using the PrimaryBeam API
+    to ensure the model adheres to the file format even if bugs are
+    introduced into the API.
+    """
+    h5file.attrs['model_type'] = 'primary_beam'
+    h5file.attrs['model_format'] = 'aperture_plane'
+    h5file.attrs['model_comment'] = 'Dummy model for testing. Do not use in production.'
+    h5file.attrs['model_created'] = '2021-04-20T12:11:00Z'
+    h5file.attrs['model_version'] = 1
+    h5file.attrs['model_author'] = 'MeerKAT SDP developers <sdpdev+katsdpmodels@ska.ac.za>'
+    h5file.attrs['antenna'] = 'm999'
+    h5file.attrs['receiver'] = 'r123'
+    h5file.attrs['band'] = 'z'
+    # x and y are deliberately set up differently to catch bugs that mix them up.
+    h5file.attrs['x_start'] = -10.0
+    h5file.attrs['x_step'] = 0.5
+    h5file.attrs['y_start'] = 8.0
+    h5file.attrs['y_step'] = -0.25
+    frequency = np.arange(64) * 1e7 + 1e9
+    h5file.create_dataset('frequency', data=frequency)
+
+    rs = np.random.RandomState()
+    shape = (2, 2, len(frequency), 80, 40)
+    data = rs.random_sample(shape) + 1j * rs.random_sample(shape)
+    # Adjust data so that beam is the identity at the centre.
+    data -= np.mean(data, axis=(3, 4), keepdims=True)
+    data[0, 0] += 1
+    data[1, 1] += 1
+    h5file.create_dataset('aperture_plane', data=data.astype(np.complex64))
+
+
+@pytest.fixture
+def aperture_plane_model(tmp_path) \
+        -> Generator[primary_beam.PrimaryBeam, None, None]:
+    path = tmp_path / 'aperture_plane_test.h5'
+    with h5py.File(path, 'w') as h5file:
+        make_aperture_plane_model_file(h5file)
+    with fetch_requests.fetch_model(path.as_uri(),
+                                    primary_beam.PrimaryBeam) as model:
+        yield model
+
+
+@pytest.fixture
+def aperture_plane_model_no_optional(tmp_path) \
+        -> Generator[primary_beam.PrimaryBeam, None, None]:
+    path = tmp_path / 'aperture_plane_test.h5'
+    with h5py.File(path, 'w') as h5file:
+        make_aperture_plane_model_file(h5file)
+        del h5file.attrs['receiver']
+        del h5file.attrs['antenna']
+        del h5file.attrs['band']
+    with fetch_requests.fetch_model(path.as_uri(),
+                                    primary_beam.PrimaryBeam) as model:
+        yield model
+
+
+def test_properties(aperture_plane_model):
+    model = aperture_plane_model
+    # approx because speed of light is not exactly 3e8 m/s
+    assert model.spatial_resolution(1 * u.GHz) == pytest.approx(0.015, rel=1e-3)
+    assert model.frequency_range() == (1000 * u.MHz, 1630 * u.MHz)
+    assert model.frequency_resolution() == 10 * u.MHz
+    # approx because speed of light is not exactly 3e8 m/s
+    assert model.inradius(1.5 * u.GHz) == pytest.approx(0.2, rel=1e-3)
+    # Radius in x is 0.3, in y is 0.6 because it has twice the aperture-plane
+    # resolution.
+    assert model.circumradius(1 * u.GHz) == pytest.approx(np.hypot(0.3, 0.6), rel=1e-3)
+    assert not model.is_circular
+    assert not model.is_unpolarized
+    assert model.antenna == 'm999'
+    assert model.receiver == 'r123'
+    assert model.band == 'z'
+
+
+def test_no_optional_properties(aperture_plane_model_no_optional):
+    model = aperture_plane_model_no_optional
+    assert model.antenna is None
+    assert model.receiver is None
+    assert model.band is None

--- a/test/test_primary_beam.py
+++ b/test/test_primary_beam.py
@@ -586,7 +586,7 @@ def test_sample_unpolarized_power(
     'frequency',
     [
         1500 * u.MHz,
-        [1250, 1300] * u.MHz,
+        [1250, 1600] * u.MHz,
         [[1250, 2000], [900, 1500]] * u.MHz
     ]
 )
@@ -597,8 +597,8 @@ def test_sample_grid(
         frame: Union[primary_beam.AltAzFrame, primary_beam.RADecFrame],
         output_type: primary_beam.OutputType) -> None:
     model = aperture_plane_model
-    l = [-0.002, 0.001, 0.0, 0.0, 0.0]
-    m = [0.0, 0.02, 0.0, -0.03, 0.01]
+    l = [-0.002, 0.001, 0.0, 0.0, 0.0, 0.3]
+    m = [0.0, 0.02, -0.6, -0.03, 0.01, 0.2]
 
     actual = model.sample_grid(l, m, frequency, frame, output_type)
     expected = model.sample(
@@ -606,10 +606,10 @@ def test_sample_grid(
         frame, output_type)
     np.testing.assert_allclose(actual, expected, atol=1e-5)
 
-    # Test output parameters
+    # Test out parameter
     out = np.zeros(expected.shape, expected.dtype)
-    ret = model.sample(
-        np.array(l)[np.newaxis, :], np.array(m)[:, np.newaxis], frequency,
+    ret = model.sample_grid(
+        l, m, frequency,
         frame, output_type,
         out=out)
     assert ret is out

--- a/test/test_primary_beam.py
+++ b/test/test_primary_beam.py
@@ -342,6 +342,13 @@ def test_sample_lm_broadcast(aperture_plane_model: primary_beam.PrimaryBeamApert
     # in a different order depending on size.
     np.testing.assert_allclose(actual, expected, atol=1e-7)
 
+    # Also check with RADecFrame
+    actual = aperture_plane_model.sample(
+        -l[np.newaxis, :], m[:, np.newaxis], frequency,
+        primary_beam.RADecFrame(0 * u.deg),
+        primary_beam.OutputType.JONES_HV)
+    np.testing.assert_allclose(actual, expected, atol=1e-7)
+
 
 @pytest.mark.parametrize(
     'l, m, frequency',

--- a/test/test_primary_beam.py
+++ b/test/test_primary_beam.py
@@ -505,3 +505,20 @@ def test_sample_radec(
         primary_beam.OutputType.JONES_HV)
     # Tolerance is high because RADecFrame doesn't account for aberration
     np.testing.assert_allclose(out_radec, out_altaz, atol=1e-4)
+
+
+def test_jones_xy(aperture_plane_model: primary_beam.PrimaryBeamAperturePlane) -> None:
+    model = aperture_plane_model
+    l = [-0.002, 0.001, 0.0, 0.0, 0.0]
+    m = [0.0, 0.02, 0.0, -0.03, 0.01]
+    # Use at least one dimension in frequency to check that tensor products use
+    # the right axes.
+    frequency = [1.25, 1.5] * u.GHz
+    frame = primary_beam.RADecFrame(30 * u.deg)
+
+    out_hv = model.sample(
+        l, m, frequency, frame, primary_beam.OutputType.JONES_HV)
+    out_xy = model.sample(
+        l, m, frequency, frame, primary_beam.OutputType.JONES_XY)
+    expected_xy = frame.jones_hv_to_xy() @ out_hv
+    np.testing.assert_allclose(out_xy, expected_xy, rtol=0, atol=1e-6)


### PR DESCRIPTION
This implement loading a primary beam from file, and sampling of the primary beam. It provides a reasonably efficient implementation, without being heavily optimised. There is still room for optimisation (particularly parallelism, but also OutputType.UNPOLARIZED_POWER could probably be improved).

There is a change to the file format, which was made to simplify and speed up the implementation, but also makes sense if in future we want to implement lazy loading: the frequency axis is moved to the front, which ensures that looking up a specific frequency accesses a contiguous block of data.