### PR TITLE
Export primary beam models to HDF5

### DIFF
--- a/src/katsdpmodels/primary_beam.py
+++ b/src/katsdpmodels/primary_beam.py
@@ -254,11 +254,8 @@ class PrimaryBeam(models.SimpleHDF5Model):
         raise NotImplementedError()      # pragma: nocover
 
     @property
-    def band(self) -> Optional[str]:
-        """String identifier of the receiver band to which this model applies.
-
-        If not known, it will be ``None``.
-        """
+    def band(self) -> str:
+        """String identifier of the receiver band to which this model applies."""
 
     def sample(self, l: ArrayLike, m: ArrayLike, frequency: u.Quantity,   # noqa: E741
                frame: Union[AltAzFrame, RADecFrame],
@@ -394,9 +391,9 @@ class PrimaryBeamAperturePlane(PrimaryBeam):
             x_step: u.Quantity, y_step: u.Quantity,
             frequency: u.Quantity, samples: np.ndarray,
             *,
+            band: str,
             antenna: Optional[str] = None,
-            receiver: Optional[str] = None,
-            band: Optional[str] = None):
+            receiver: Optional[str] = None) -> None:
         super().__init__()
         # Canonicalise the units to simplify to_hdf5 (and also remove the
         # cost of conversions when methods are called with canonical units,
@@ -476,7 +473,7 @@ class PrimaryBeamAperturePlane(PrimaryBeam):
         return self._receiver
 
     @property
-    def band(self) -> Optional[str]:
+    def band(self) -> str:
         return self._band
 
     def _prepare_samples(self, frequency: u.Quantity,
@@ -758,7 +755,7 @@ class PrimaryBeamAperturePlane(PrimaryBeam):
         return cls(x_start, y_start, x_step, y_step, frequency, samples,
                    antenna=models.get_hdf5_attr(attrs, 'antenna', str),
                    receiver=models.get_hdf5_attr(attrs, 'receiver', str),
-                   band=models.get_hdf5_attr(attrs, 'band', str))
+                   band=models.get_hdf5_attr(attrs, 'band', str, required=True))
 
     @classmethod
     def from_katholog(cls: Type[_P], model, *,

--- a/test/test_primary_beam.py
+++ b/test/test_primary_beam.py
@@ -127,11 +127,17 @@ def test_no_optional_properties(aperture_plane_model_file: h5py.File) -> None:
     h5file = aperture_plane_model_file
     del h5file.attrs['receiver']
     del h5file.attrs['antenna']
-    del h5file.attrs['band']
     with serve_model(h5file) as model:
         assert model.antenna is None
         assert model.receiver is None
-        assert model.band is None
+
+
+def test_no_band(aperture_plane_model_file: h5py.File) -> None:
+    h5file = aperture_plane_model_file
+    del h5file.attrs['band']
+    with pytest.raises(models.DataError, match="attribute 'band' is missing"):
+        with serve_model(h5file):
+            pass
 
 
 def test_single_frequency(aperture_plane_model_file: h5py.File) -> None:

--- a/test/test_primary_beam.py
+++ b/test/test_primary_beam.py
@@ -17,8 +17,9 @@
 """Tests for :mod:`katsdpmodels.primary_beam`"""
 
 import contextlib
+import io
 import pathlib
-from typing import Generator, Any, Union, cast
+from typing import Generator, Any, Union, Optional, cast
 
 import astropy.units as u
 from astropy import constants
@@ -603,3 +604,28 @@ def test_sample_grid(
         out=out)
     assert ret is out
     np.testing.assert_array_equal(out, actual)
+
+
+@pytest.mark.parametrize(
+    'antenna, receiver',
+    [
+        ('m999', 'r123'),
+        (None, None)
+    ]
+)
+def test_to_file(aperture_plane_model: primary_beam.PrimaryBeamAperturePlane,
+                 antenna: Optional[str], receiver: Optional[str]) -> None:
+    model = aperture_plane_model
+    model._antenna = antenna
+    model._receiver = receiver
+    fh = io.BytesIO()
+    model.to_file(fh, content_type='application/x-hdf5')
+    fh.seek(0)
+    new_model = primary_beam.PrimaryBeam.from_file(
+        fh, 'http://test.invalid/test.h5', content_type='application/x-hdf5')
+    assert isinstance(new_model, primary_beam.PrimaryBeamAperturePlane)
+    assert new_model.antenna == antenna
+    assert new_model.receiver == receiver
+    assert new_model.band == model.band
+    np.testing.assert_equal(new_model.frequency, model.frequency)
+    np.testing.assert_equal(new_model.samples, model.samples)


### PR DESCRIPTION
Previously only the import path was implemented.

There are a few other changes because I realised there was a discrepancy between the file format specification (which said `band` was required) and the class (which made it optional). It's now required.