### PR TITLE
SPR1-969: vectorise RADecFrame

### DIFF
--- a/src/katsdpmodels/primary_beam.py
+++ b/src/katsdpmodels/primary_beam.py
@@ -321,7 +321,7 @@ class PrimaryBeam(models.SimpleHDF5Model):
         :code:`sample(l[np.newaxis, :], m[:, np.newaxis], ...)`, but may be
         significantly faster (depending on the implementation), and is not
         guaranteed to give bit-identical results. This advantage may be lost
-        when using :class:`AltAzFrame` with a non-zero parallactic angle.
+        when using :class:`RADecFrame` with a non-zero parallactic angle.
 
         The grid need not be regularly spaced, but an output is generated for
         each combination of `l`, `m` and `frequency`.

--- a/src/katsdpmodels/primary_beam.py
+++ b/src/katsdpmodels/primary_beam.py
@@ -169,17 +169,12 @@ class RADecFrame(ShapedLikeNDArray):
         # the transformation to AzEl is not rigid (does not preserve great
         # circles).
         target_icrs = target.icrs
-        if target_icrs.dec > 0:
-            sign = -1
-        else:
-            sign = 1
+        sign = np.where(target_icrs.dec > 0, -1, 1)
         pole = target_icrs.directional_offset_by(0 * u.rad, sign * 1e-5 * u.rad)
         # directional_offset_by doesn't preserve these extra attributes
-        pole.obstime = target_icrs.obstime
-        pole.location = target_icrs.location
+        pole = SkyCoord(pole, obstime=target_icrs.obstime, location=target_icrs.location)
         pa = target.altaz.position_angle(pole.altaz)
-        if sign == -1:
-            pa += np.pi * u.rad
+        pa += np.where(sign == -1, np.pi * u.rad, 0)
         return cls.from_parallactic_angle(pa)
 
 

--- a/src/katsdpmodels/primary_beam.py
+++ b/src/katsdpmodels/primary_beam.py
@@ -703,8 +703,8 @@ class PrimaryBeamAperturePlane(PrimaryBeam):
             lm = frame.lm_to_hv() @ lm
             # Unpack again. If frame is vectorised, the rest will have extra
             # leading dimensions.
-            l_ = lm[0].reshape(frame.shape + l_.shape)
-            m_ = lm[1].reshape(frame.shape + m_.shape)
+            l_ = lm[..., 0, :].reshape(frame.shape + l_.shape)
+            m_ = lm[..., 1, :].reshape(frame.shape + m_.shape)
         elif not isinstance(frame, AltAzFrame):
             raise TypeError(f'frame must be RADecFrame or AltAzFrame, not {type(frame)}')
         l_ = _asarray(l_, np.float32)

--- a/src/katsdpmodels/primary_beam.py
+++ b/src/katsdpmodels/primary_beam.py
@@ -78,6 +78,10 @@ class RADecFrame:
     topocentric frames, but it's ignored as it is typically much smaller than
     features of the primary beam.
 
+    This class should not be constructed directly, as the constructor
+    signature is subject to change in future. Use the factory methods
+    such as :meth:`from_parallactic_angle` and :meth:`from_sky_coord`.
+
     Parameters
     ----------
     parallactic_angle
@@ -108,6 +112,11 @@ class RADecFrame:
         return np.array([[s, c], [-c, s]])
 
     @classmethod
+    def from_parallactic_angle(cls, parallactic_angle: u.Quantity) -> 'RADecFrame':
+        """Generate a frame from a parallactic angle."""
+        return cls(parallactic_angle)
+
+    @classmethod
     def from_sky_coord(cls, target: SkyCoord) -> 'RADecFrame':
         """Generate a frame from a target (assuming an AltAz mount).
 
@@ -131,7 +140,7 @@ class RADecFrame:
         pa = target.altaz.position_angle(pole.altaz)
         if sign == -1:
             pa += np.pi * u.rad
-        return cls(pa)
+        return cls.from_parallactic_angle(pa)
 
 
 class OutputType(enum.Enum):

--- a/test/test_primary_beam.py
+++ b/test/test_primary_beam.py
@@ -41,7 +41,7 @@ FRAME_OUTPUT_TYPE_COMBOS = [
     (frame, output_type)
     for frame in [primary_beam.AltAzFrame(),
                   primary_beam.RADecFrame.from_parallactic_angle(40 * u.deg),
-                  primary_beam.RADecFrame.from_parallactic_angle([40, 80] * u.deg)]
+                  primary_beam.RADecFrame.from_parallactic_angle([[40], [80]] * u.deg)]
     for output_type in primary_beam.OutputType
     if (isinstance(frame, primary_beam.RADecFrame)
         or output_type in {primary_beam.OutputType.JONES_HV,
@@ -586,7 +586,7 @@ def _test_sample_radec_array(
         [model.sample(l, m, frequency, frame, output_type) for frame in scalar_frames],
         axis=1
     )
-    out = model.sample(l, m, frequency, vector_frame, output_type)
+    out = model.sample(l, m, frequency, vector_frame[:, np.newaxis], output_type)
     np.testing.assert_allclose(out, expected, atol=1e-5)
 
 
@@ -658,6 +658,8 @@ def test_sample_grid(
     l = [-0.002, 0.001, 0.0, 0.0, 0.0, 0.3]
     m = [0.0, 0.02, -0.6, -0.03, 0.01, 0.2]
 
+    # Ensure array axes in frame are orthogonal to l, m
+    frame = frame[..., np.newaxis, np.newaxis]
     actual = model.sample_grid(l, m, frequency, frame, output_type)
     expected = model.sample(
         np.array(l)[np.newaxis, :], np.array(m)[:, np.newaxis], frequency,

--- a/test/test_primary_beam.py
+++ b/test/test_primary_beam.py
@@ -40,7 +40,7 @@ import katsdpmodels.fetch.requests as fetch_requests
 FRAME_OUTPUT_TYPE_COMBOS = [
     (frame, output_type)
     for frame in [primary_beam.AltAzFrame(),
-                  primary_beam.RADecFrame(parallactic_angle=40 * u.deg)]
+                  primary_beam.RADecFrame.from_parallactic_angle(40 * u.deg)]
     for output_type in primary_beam.OutputType
     if (isinstance(frame, primary_beam.RADecFrame)
         or output_type in {primary_beam.OutputType.JONES_HV,
@@ -349,7 +349,7 @@ def test_sample_lm_broadcast(aperture_plane_model: primary_beam.PrimaryBeamApert
     # Also check with RADecFrame
     actual = aperture_plane_model.sample(
         -l[np.newaxis, :], m[:, np.newaxis], frequency,
-        primary_beam.RADecFrame(0 * u.deg),
+        primary_beam.RADecFrame.from_parallactic_angle(0 * u.deg),
         primary_beam.OutputType.JONES_HV)
     np.testing.assert_allclose(actual, expected, atol=1e-7)
 
@@ -514,7 +514,7 @@ def test_samples_jones_xy(aperture_plane_model: primary_beam.PrimaryBeamAperture
     # Use at least one dimension in frequency to check that tensor products use
     # the right axes.
     frequency = [1.25, 1.5] * u.GHz
-    frame = primary_beam.RADecFrame(30 * u.deg)
+    frame = primary_beam.RADecFrame.from_parallactic_angle(30 * u.deg)
 
     out_hv = model.sample(
         l, m, frequency, frame, primary_beam.OutputType.JONES_HV)
@@ -538,7 +538,7 @@ def test_sample_mueller(aperture_plane_model: primary_beam.PrimaryBeamAperturePl
     # Use at least one dimension in frequency to check that tensor products use
     # the right axes.
     frequency = [1.25, 1.5] * u.GHz
-    frame = primary_beam.RADecFrame(30 * u.deg)
+    frame = primary_beam.RADecFrame.from_parallactic_angle(30 * u.deg)
 
     mueller = model.sample(l, m, frequency, frame, primary_beam.OutputType.MUELLER)
     B = voltages @ voltages.T.conj()            # Matrix of [[XX, XY], [YX, YY]]
@@ -562,7 +562,7 @@ def test_sample_unpolarized_power(
     l = [-0.002, 0.001, 0.0, 0.0, 0.0]
     m = [0.0, 0.02, 0.0, -0.03, 0.01]
     frequency = [1.25, 1.5] * u.GHz
-    frame = primary_beam.RADecFrame(parallactic_angle=30 * u.deg)
+    frame = primary_beam.RADecFrame.from_parallactic_angle(30 * u.deg)
 
     mueller = model.sample(
         l, m, frequency, frame, primary_beam.OutputType.MUELLER)


### PR DESCRIPTION
The main change is to allow an array-like RADecFrame to be used to sample from multiple frames at once (the main use case being multiple points in time during an observation by using a vector `obstime`. Semi-related changes are:

- Add RADecFrame.from_parallactic_angle as the recommended way to construct a frame from parallactic angle. This leaves open the possibility of changing the constructor to take other internal representations (e.g. the transformation matrices themselves, which would allow for scaling to account for aberration).
- Derive RADecFrame from astropy's ShapedLikeNDArray helper that makes it possible to treat an array frame somewhat like an ndarray.