### PR TITLE
Don't modify inputs in PrimaryBeamAperturePlane.sample

### DIFF
--- a/src/katsdpmodels/primary_beam.py
+++ b/src/katsdpmodels/primary_beam.py
@@ -701,8 +701,12 @@ class PrimaryBeamAperturePlane(PrimaryBeam):
         m_ = _asarray(m)
         l_, m_ = np.broadcast_arrays(l_, m_)
         # numba seems to trigger a FutureWarning when it checks the writeable
-        # flag on these broadcast arrays. Suppress it by making them
-        # explicitly readonly.
+        # flag on these broadcast arrays. Suppress it by making them explicitly
+        # readonly. Explicitly take views so that we don't modify the input
+        # arrays (which could otherwise happen if the transformations above are
+        # no-ops).
+        l_ = l_.view()
+        m_ = m_.view()
         l_.flags.writeable = False
         m_.flags.writeable = False
         if isinstance(frame, RADecFrame):

--- a/test/test_primary_beam.py
+++ b/test/test_primary_beam.py
@@ -355,6 +355,16 @@ def test_sample_lm_broadcast(aperture_plane_model: primary_beam.PrimaryBeamApert
     np.testing.assert_allclose(actual, expected, atol=1e-7)
 
 
+def test_sample_lm_np_flags(aperture_plane_model: primary_beam.PrimaryBeamAperturePlane) -> None:
+    """Check that flags on l and m arrays are not modified."""
+    l = np.array([0.01, 0.02])
+    m = np.array([0.03, 0.04])
+    aperture_plane_model.sample(
+        l, m, 1500 * u.MHz, primary_beam.AltAzFrame(), primary_beam.OutputType.JONES_HV)
+    assert l.flags.writeable
+    assert m.flags.writeable
+
+
 @pytest.mark.parametrize(
     'l, m, frequency',
     [


### PR DESCRIPTION
The flags of the input arrays could be modified in some cases.