### PR TITLE
Primary beam sampling optimisations

### DIFF
--- a/src/katsdpmodels/primary_beam.py
+++ b/src/katsdpmodels/primary_beam.py
@@ -600,7 +600,7 @@ class PrimaryBeamAperturePlane(PrimaryBeam):
             raise ValueError(f'Unrecognised output_type {output_type}')
 
     @staticmethod
-    @numba.njit
+    @numba.njit(parallel=True)
     def _sample_impl(aperture: np.ndarray, xf: np.ndarray, yf: np.ndarray,
                      l: np.ndarray, m: np.ndarray, out: np.ndarray) -> None:
         """Numba implementation details of :meth:`_sample_altaz_jones`.
@@ -616,7 +616,7 @@ class PrimaryBeamAperturePlane(PrimaryBeam):
         out
             Output array
         """
-        for freq_idx in np.ndindex(xf.shape[:-1]):
+        for freq_idx in numba.prange(xf.shape[0]):
             # Frequency-specific 1D arrays
             x = xf[freq_idx]
             y = yf[freq_idx]
@@ -626,7 +626,7 @@ class PrimaryBeamAperturePlane(PrimaryBeam):
             for i in range(2):
                 for j in range(2):
                     tmp = coeff2 @ ap[i, j]
-                    out_chunk = out[freq_idx + (...,) + (i, j)]
+                    out_chunk = out[freq_idx, :, i, j]
                     for lm_idx in range(l.shape[0]):
                         out_chunk[lm_idx] = np.dot(tmp[lm_idx], coeff1[lm_idx])
 
@@ -653,20 +653,23 @@ class PrimaryBeamAperturePlane(PrimaryBeam):
         elif out.shape != out_shape:
             raise ValueError(f'out must have shape {out_shape}, not {out.shape}')
 
+        # Numba can't handle the broadcasting involved in multi-dimensional
+        # l/m/freq, so flatten. Assign to shape instead of reshape to ensure
+        # no copying.
+        out_view = out.view()
+        out_view.shape = (frequency.size, l.size, 2, 2)
+        flat_frequency = frequency.ravel()
+
         # Compute x and y in wavelengths
-        wavenumber = frequency.to('m^-1', equivalencies=u.spectral())
+        wavenumber = flat_frequency.to('m^-1', equivalencies=u.spectral())
         xf = _asarray(np.multiply.outer(wavenumber, self.x), np.float32)
         yf = _asarray(np.multiply.outer(wavenumber, self.y), np.float32)
-        # Numba can't handle the broadcasting involved in multi-dimensional
-        # l/m, so flatten. Assign to shape instead of reshape to ensure no
-        # copying.
-        out_view = out.view()
-        out_view.shape = frequency.shape + (l.size, 2, 2)
-        samples = self._prepare_samples(frequency)
+        samples = self._prepare_samples(flat_frequency)
         self._sample_impl(samples, xf, yf, l.ravel(), m.ravel(), out_view)
 
         # Check if there are any points that may lie outside the valid l/m
         # region. If not (common case) we can avoid computing masks.
+        wavenumber = wavenumber.reshape(frequency.shape)  # Undo ravelling
         max_l = np.max(np.abs(l))
         max_m = np.max(np.abs(m))
         max_wavenumber = np.max(wavenumber)


### PR DESCRIPTION
A handful of optimisations to primary beam sampling. Refer to the individual commits for more details. For sampling on a grid in the AltAz frame the performance roughly doubles on my laptop (when sampling 1000x1000 grids - for small amounts of data it gets a bit slower). For other sampling the performance is about 3x when there are many frequencies (since parallelisation is over frequency, there is no benefit if there is only one frequency).

Closes SPR1-949.