### PR TITLE
Bump sphinxcontrib-tikz to the latest version

### DIFF
--- a/doc-requirements.txt
+++ b/doc-requirements.txt
@@ -1,5 +1,5 @@
 -c https://raw.githubusercontent.com/ska-sa/katsdpdockerbase/master/docker-base-build/base-requirements.txt
 
 sphinx
-sphinxcontrib-tikz==0.4.9
+sphinxcontrib-tikz==0.4.15
 sphinx-rtd-theme


### PR DESCRIPTION
readthedocs builds were failing because the previous version is
incompatible with the latest setuptools.
