### PR TITLE
Use aioresponses 0.7.6 to go with aiohttp >= 3.9

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,6 +1,6 @@
 -c https://raw.githubusercontent.com/ska-sa/katsdpdockerbase/master/docker-base-build/base-requirements.txt
 
-aioresponses==0.7.1
+aioresponses==0.7.6
 pytest
 pytest-asyncio==0.12.0
 pytest-cov


### PR DESCRIPTION
Now that docker-base has aiohttp 3.9.3, get the latest aioresponses. This fixes a bug that "object Mock can't be used in 'await' expression" (see pnuckowski/aioresponses#248), which affects the 7 unit tests in test_fetch_aiohttp using the `mock_aioresponses` fixture.

It seems that aioresponses 0.7.6 needs Python 3.7 while katsdpmodels itself still only requires Python 3.6. This discrepancy seems OK for now as the tests are run on Python 3.8 and soon the minimum version will be bumped anyway.